### PR TITLE
Builds Rack 0.6.2 Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,21 +102,23 @@ DISTRIBUTABLES += $(wildcard LICENSE*) res docs patches README.md
 # Include the VCV plugin Makefile framework
 include $(RACK_DIR)/plugin.mk
 
-# Obvioulsy get rid of this one day
-FLAGS += 	-Wno-undefined-bool-conversion \
+
+# Add Surge Specific make flags based on architecture
+ifdef ARCH_MAC
+	# Obvioulsy get rid of this one day
+	FLAGS += 	-Wno-undefined-bool-conversion \
 	-Wno-unused-variable \
 	-Wno-reorder \
 	-Wno-char-subscripts \
 	-Wno-sign-compare \
 	-Wno-ignored-qualifiers \
 	-Wno-c++17-extensions
-
-# Add Surge Specific make flags based on architecture
-ifdef ARCH_MAC
 	FLAGS += -DMAC -D"_aligned_malloc(x,a)=malloc(x)" -D"_aligned_free(x)=free(x)"
 endif
 
-ifdef ARCH_LINUX
+ifdef ARCH_LIN
+	FLAGS += -DLINUX -D"_aligned_malloc(x,a)=malloc(x)" -D"_aligned_free(x)=free(x)"
+	FLAGS += -Isurge/src/linux
 endif
 
 ifdef ARCH_WIN

--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -2,6 +2,7 @@
 #include "Surge.hpp"
 #include "dsp/effect/Effect.h"
 #include "rack.hpp"
+#include <cstring>
 
 template <typename TBase> struct SurgeFX : virtual TBase {
     enum ParamIds { FX_TYPE, FX_PARAM_0, NUM_PARAMS = FX_PARAM_0 + 12 };
@@ -124,7 +125,7 @@ template <typename TBase> struct SurgeFX : virtual TBase {
                     orderTrack.push_back(std::pair<int, int>(
                         i, i * 2 + fxstorage->p[i].posy_offset));
                 } else {
-                    orderTrack.push_back(std::pair<int, int>(i, INT_MAX));
+                    orderTrack.push_back(std::pair<int, int>(i, 10000));
                 }
             }
             std::sort(

--- a/src/SurgeRackGUI.hpp
+++ b/src/SurgeRackGUI.hpp
@@ -1,6 +1,7 @@
 #include "Surge.hpp"
 #include "rack.hpp"
 #include <map>
+#include <functional>
 
 #ifndef RACK_V1
 #include "widgets.hpp"


### PR DESCRIPTION
Set up the makefile and include the missing headers so that we also
get a clean 0.6.2 build on Linux. Haven't tested if this works, but
have confirmed that make dist results in an asset.

Closes #14 (build on linux)