### PR TITLE
Final Fixes for CI Pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ LDFLAGS += -framework CoreFoundation -framework CoreServices
 endif
 
 ifdef ARCH_WIN
-LDFLAGS += -lstdc++fs
+SOURCES += $(SRL)/filesystem/filesystem.cpp
 endif
 
 # Add files to the ZIP package when running `make dist`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,12 @@ jobs:
     displayName: Get Surge SubModule
 
   - bash: |
+      which g++
+      g++ --version
+    displayName: Dump Windows Versions
+    condition: variables.isWindows
+
+  - bash: |
       export RACK_DIR=$AGENT_TEMPDIRECTORY/Rack-SDK
       export CC=gcc
       export CPP=g++


### PR DESCRIPTION
Final fixes to make Rack build in the CI Pipeline on Windows
(which basically amount to "don't assume the C++17 filesystem
API is there; and g++ on windows is not the same as WINDOWS
in surge). So a set of directies in surge and make rules here and
we are good.