### PR TITLE
Layout; Screws; Versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,16 @@ ifneq ("$(wildcard $(RACK_DIR)/helper.py)","")
 	RACK_VERSION=1
 	RACK_FLAG=-DRACK_V1
 	RACK_GO=(cd ~/dev/VCVRack/V1/Rack && make run)
+	DISPLAY_VERSION=surge-rack-alpha.1.$(shell git rev-parse --short HEAD).$(shell cd surge && git rev-parse --short HEAD)
 else
 	RACK_VERSION=062
 	RACK_FLAG=-DRACK_V062
 	SLUG=SurgeRack
 	VERSION=0.6.0
 	RACK_GO=	unzip -o dist/$(SLUG)-$(VERSION)-$(ARCH).zip -d ~/Documents/Rack/plugins && (cd ~/Documents/Rack && /Applications/Rack.app/Contents/MacOS/Rack ) 
+	DISPLAY_VERSION=surge-rack-alpha.0.6.$(shell git rev-parse --short HEAD).$(shell cd surge && git rev-parse --short HEAD)
 endif
+
 
 include $(RACK_DIR)/arch.mk
 
@@ -26,7 +29,6 @@ FLAGS += -Isurge/src/common -Isurge/src/common/dsp \
 FLAGS += $(RACK_FLAG)
 
 CFLAGS +=
-CXXFLAGS += 
 
 # Careful about linking to shared libraries, since you can't assume much about the user's environment and library search path.
 # Static libraries are fine.
@@ -129,11 +131,13 @@ ifdef ARCH_MAC
 	-Wno-ignored-qualifiers \
 	-Wno-c++17-extensions
 	FLAGS += -DMAC -D"_aligned_malloc(x,a)=malloc(x)" -D"_aligned_free(x)=free(x)"
+	FLAGS += -DDISPLAY_VERSION="$(DISPLAY_VERSION)"
 endif
 
 ifdef ARCH_LIN
 	FLAGS += -DLINUX -D"_aligned_malloc(x,a)=malloc(x)" -D"_aligned_free(x)=free(x)"
 	FLAGS += -Isurge/src/linux
+	FLAGS += -DDISPLAY_VERSION="$(DISPLAY_VERSION)"
 endif
 
 ifdef ARCH_WIN
@@ -142,7 +146,9 @@ ifdef ARCH_WIN
 		 -Wno-unused-variable -Wno-char-subscripts -Wno-reorder \
 		 -Wno-int-in-bool-context 
 	FLAGS += -DWINDOWS -Isurge/src/windows
+	FLAGS += -DDISPLAY_VERSION=FIXTHIS_ON_WINDOWS
 endif
+
 
 COMMUNITY_ISSUE=https://github.com/VCVRack/community/issues/FIXME
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,8 @@ jobs:
       export RACK_DIR=$AGENT_TEMPDIRECTORY/Rack-SDK
       export CC=gcc
       export CPP=g++
+      echo RACK_DIR is ${RACK_DIR}
+      ls ${RACK_DIR}/include
       make win-dist
 
       mkdir products_win/

--- a/patches/SurgeFX.vcv
+++ b/patches/SurgeFX.vcv
@@ -344,7 +344,7 @@
       "model": "SurgeFX",
       "params": [
         {
-          "value": 1.60749817
+          "value": 0.17550002
         },
         {
           "value": 0.309000015
@@ -353,13 +353,13 @@
           "value": 0.64800024
         },
         {
-          "value": 0.677999854
+          "value": 0.410999984
         },
         {
           "value": 0.694999933
         },
         {
-          "value": 0.658500314
+          "value": 0.685500264
         },
         {
           "value": 0.158499897
@@ -431,7 +431,7 @@
           "value": 0.00449999981
         },
         {
-          "value": 0.0
+          "value": 0.123000011
         },
         {
           "value": 0.0
@@ -503,7 +503,7 @@
       ]
     }
   ],
-  "id": 15,
+  "id": 16,
   "cables": [
     {
       "outputModuleId": 19,
@@ -615,6 +615,13 @@
       "outputId": 1,
       "inputModuleId": 30,
       "inputId": 8,
+      "color": "#c9b70e"
+    },
+    {
+      "outputModuleId": 31,
+      "outputId": 3,
+      "inputModuleId": 30,
+      "inputId": 4,
       "color": "#c9b70e"
     }
   ]

--- a/patches/SurgeFX_v062.vcv
+++ b/patches/SurgeFX_v062.vcv
@@ -27,95 +27,31 @@
       "model": "SurgeRack",
       "params": [
         {
-          "paramId": 27,
+          "paramId": 25,
           "value": 1.0
         },
         {
-          "paramId": 28,
+          "paramId": 26,
           "value": 1.0
         },
         {
           "paramId": 0,
-          "value": 0.969999611
+          "value": 1.28500009
         },
         {
-          "paramId": 14,
+          "paramId": 27,
+          "value": 0.5
+        },
+        {
+          "paramId": 13,
           "value": 0.0
         },
         {
           "paramId": 1,
-          "value": 0.540500045
+          "value": 0.576500058
         },
         {
-          "paramId": 20,
-          "value": 0.0
-        },
-        {
-          "paramId": 7,
-          "value": 0.5825001
-        },
-        {
-          "paramId": 15,
-          "value": 0.0
-        },
-        {
-          "paramId": 2,
-          "value": 0.5
-        },
-        {
-          "paramId": 21,
-          "value": 0.0
-        },
-        {
-          "paramId": 8,
-          "value": 0.5
-        },
-        {
-          "paramId": 16,
-          "value": 0.0
-        },
-        {
-          "paramId": 3,
-          "value": 0.638000131
-        },
-        {
-          "paramId": 22,
-          "value": 0.0
-        },
-        {
-          "paramId": 9,
-          "value": 0.351500005
-        },
-        {
-          "paramId": 17,
-          "value": 0.0
-        },
-        {
-          "paramId": 4,
-          "value": 0.648500085
-        },
-        {
-          "paramId": 23,
-          "value": 0.0
-        },
-        {
-          "paramId": 10,
-          "value": 0.68900001
-        },
-        {
-          "paramId": 18,
-          "value": 0.0
-        },
-        {
-          "paramId": 5,
-          "value": 0.5
-        },
-        {
-          "paramId": 24,
-          "value": 0.0
-        },
-        {
-          "paramId": 11,
+          "paramId": 33,
           "value": 0.5
         },
         {
@@ -123,11 +59,123 @@
           "value": 0.0
         },
         {
+          "paramId": 7,
+          "value": 0.5825001
+        },
+        {
+          "paramId": 28,
+          "value": 0.5
+        },
+        {
+          "paramId": 14,
+          "value": 0.0
+        },
+        {
+          "paramId": 2,
+          "value": 0.663500071
+        },
+        {
+          "paramId": 34,
+          "value": 0.5
+        },
+        {
+          "paramId": 20,
+          "value": 0.0
+        },
+        {
+          "paramId": 8,
+          "value": 0.5
+        },
+        {
+          "paramId": 29,
+          "value": 0.5
+        },
+        {
+          "paramId": 15,
+          "value": 0.0
+        },
+        {
+          "paramId": 3,
+          "value": 0.639500141
+        },
+        {
+          "paramId": 35,
+          "value": 0.5
+        },
+        {
+          "paramId": 21,
+          "value": 0.0
+        },
+        {
+          "paramId": 9,
+          "value": 0.47300005
+        },
+        {
+          "paramId": 30,
+          "value": 0.5
+        },
+        {
+          "paramId": 16,
+          "value": 0.0
+        },
+        {
+          "paramId": 4,
+          "value": 0.648500085
+        },
+        {
+          "paramId": 36,
+          "value": 0.5
+        },
+        {
+          "paramId": 22,
+          "value": 0.0
+        },
+        {
+          "paramId": 10,
+          "value": 0.68900001
+        },
+        {
+          "paramId": 31,
+          "value": 0.5
+        },
+        {
+          "paramId": 17,
+          "value": 0.0
+        },
+        {
+          "paramId": 5,
+          "value": 0.5
+        },
+        {
+          "paramId": 37,
+          "value": 0.5
+        },
+        {
+          "paramId": 23,
+          "value": 0.0
+        },
+        {
+          "paramId": 11,
+          "value": 0.5
+        },
+        {
+          "paramId": 32,
+          "value": 0.5
+        },
+        {
+          "paramId": 18,
+          "value": 0.0
+        },
+        {
           "paramId": 6,
           "value": 0.213499963
         },
         {
-          "paramId": 25,
+          "paramId": 38,
+          "value": 0.5
+        },
+        {
+          "paramId": 24,
           "value": 0.0
         },
         {

--- a/src/SurgeFX.cpp
+++ b/src/SurgeFX.cpp
@@ -51,16 +51,24 @@ SurgeFXWidget::SurgeFXWidget(SurgeFXWidget::M *module)
 
     int parmMargin = 3;
 
-    addChild(new SurgeRoundedRect(rack::Vec(SCREW_WIDTH*6.5,10),
-                                  rack::Vec(SCREW_WIDTH*18,45)));
+    addChild(new SurgeRoundedRect(rack::Vec(box.size.x/4 + 36, 15),
+                                  rack::Vec(box.size.x/2 - SCREW_WIDTH/2 - 36, 34)));
 
-    addChild(TextDisplayLight::create(rack::Vec(SCREW_WIDTH*6.5 + 3, 13),
-                                      rack::Vec(SCREW_WIDTH*18, 39),
+    addChild(TextDisplayLight::create(rack::Vec(box.size.x/4 + 2 + 36, 17),
+                                      rack::Vec(box.size.x/2 - SCREW_WIDTH/2 - 36, 31),
                                       [module]() { return module ? module->getEffectNameString() : "null"; },
                                       [module]() { return module ? module->getEffectNameStringDirty() : true; },
-                                      25, NVG_ALIGN_BOTTOM | NVG_ALIGN_LEFT));
-    addParam(rack::createParam<SurgeKnob>(
-                 rack::Vec(SCREW_WIDTH*1, 4), module, M::FX_TYPE
+                                      20, NVG_ALIGN_BOTTOM | NVG_ALIGN_LEFT, SurgeStyle::surgeWhite()));
+    TextDisplayLight *tdl;
+    addChild(tdl = TextDisplayLight::create(rack::Vec(box.size.x/4 + 2 + 36, 16),
+                                            rack::Vec(box.size.x/2 - SCREW_WIDTH/2 - 36, 31),
+                                            []() { return "Effect Type"; },
+                                            []() { return false; },
+                                            12, NVG_ALIGN_TOP | NVG_ALIGN_LEFT));
+    tdl->font = SurgeStyle::fontFaceCondensed();
+
+    addParam(rack::createParam<SurgeKnobRooster>(
+                 rack::Vec(box.size.x / 4, 15), module, M::FX_TYPE
 #ifndef RACK_V1
                  , 0, 10, 1
 #endif                 

--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -26,10 +26,13 @@ template <typename TBase> struct SurgeFX : virtual TBase {
     enum OutputIds { OUTPUT_R_OR_MONO, OUTPUT_L, NUM_OUTPUTS };
     enum LightIds { NUM_LIGHTS };
 
+
     float paramCache[NUM_FX_PARAMS];
     std::string paramDisplayCache[NUM_FX_PARAMS];
     bool paramDisplayDirty[NUM_FX_PARAMS];
 
+    std::string effectNameCache = "";
+    bool effectNameCacheDirty = true;
     std::string labelCache[NUM_FX_PARAMS];
     bool labelCacheDirty[NUM_FX_PARAMS];
     std::string sublabelCache[NUM_FX_PARAMS];
@@ -114,6 +117,9 @@ template <typename TBase> struct SurgeFX : virtual TBase {
                                         storage->getPatch().globaldata));
         surge_effect->init();
         surge_effect->init_ctrltypes();
+
+        effectNameCacheDirty = true;
+        effectNameCache = surge_effect->get_effectname();
 
         fxstorage->type.val.i = 1;
         
@@ -227,6 +233,8 @@ template <typename TBase> struct SurgeFX : virtual TBase {
             surge_effect->init();
             surge_effect->init_ctrltypes();
             reorderSurgeParams();
+            effectNameCacheDirty = true;
+            effectNameCache = surge_effect->get_effectname();
         }
 
         for (int i = 0; i < n_fx_params; ++i) {
@@ -301,11 +309,13 @@ template <typename TBase> struct SurgeFX : virtual TBase {
     }
 
     std::string getEffectNameString() {
-        return ( surge_effect.get() ? surge_effect->get_effectname() : "null" );
+        return effectNameCache;
     }
 
     bool getEffectNameStringDirty() {
-        return true; // fixme of course
+        auto res = effectNameCacheDirty;
+        effectNameCacheDirty = false;
+        return res;
     }
 
     std::unique_ptr<Effect> surge_effect;

--- a/src/SurgeRackGUI.hpp
+++ b/src/SurgeRackGUI.hpp
@@ -161,6 +161,10 @@ struct SurgeRackBG : public rack::TransparentWidget {
         BufferedDrawFunctionWidget *bdw = new BufferedDrawFunctionWidget(
             pos, size, [this](NVGcontext *vg) { this->drawBG(vg); });
         addChild(bdw);
+        addChild(rack::createWidget<rack::ScrewSilver>(rack::Vec(box.size.x - SCREW_WIDTH, box.size.y - SCREW_WIDTH)));
+        addChild(rack::createWidget<rack::ScrewSilver>(rack::Vec(0, box.size.y - SCREW_WIDTH)));
+        addChild(rack::createWidget<rack::ScrewSilver>(rack::Vec(box.size.x - SCREW_WIDTH, 0)));
+        addChild(rack::createWidget<rack::ScrewSilver>(rack::Vec(0, 0)));
     }
 
     bool hasInput = false;
@@ -185,12 +189,26 @@ struct SurgeRackBG : public rack::TransparentWidget {
         nvgFillColor(vg, SurgeStyle::surgeOrange());
         nvgFill(vg);
 
+        nvgBeginPath(vg);
+        nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
+        nvgFillColor(vg, SurgeStyle::surgeWhite());
+        nvgFontFaceId(vg, fontId);
+        nvgFontSize(vg, 11);
+        nvgText(vg, box.size.x/2, box.size.y - 3, TOSTRING(DISPLAY_VERSION), NULL);
+
+        nvgBeginPath(vg);
+        nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
+        nvgFillColor(vg, SurgeStyle::surgeWhite());
+        nvgFontFaceId(vg, fontId);
+        nvgFontSize(vg, 30);
+        nvgText(vg, box.size.x/2, box.size.y - 16, displayName.c_str(), NULL);
+
         for (int i = 0; i < 2; ++i) {
             if ((i == 0 && hasInput) || (i == 1 && hasOutput)) {
                 nvgBeginPath(vg);
-                int x0 = 0;
+                int x0 = 7;
                 if (i == 1)
-                    x0 = box.size.x - ioRegionWidth - 2 * ioMargin;
+                    x0 = box.size.x - ioRegionWidth - 2 * ioMargin - 7;
                 NVGpaint sideGradient;
                 if (i == 0)
                     sideGradient = nvgLinearGradient(
@@ -217,38 +235,38 @@ struct SurgeRackBG : public rack::TransparentWidget {
                 if (i == 0) {
                     nvgSave(vg);
                     nvgTranslate(vg, x0 + ioMargin + 2,
-                                 box.size.y - (box.size.y - orangeLine) / 2);
-                    nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+                                 orangeLine + ioMargin * 1.5);
+                    nvgTextAlign(vg, NVG_ALIGN_RIGHT | NVG_ALIGN_TOP);
                     nvgRotate(vg, -M_PI / 2);
                     nvgText(vg, 0, 0, "Input", NULL);
                     nvgRestore(vg);
                 } else {
                     nvgSave(vg);
                     nvgTranslate(vg, x0 + ioMargin + ioRegionWidth - 2,
-                                 box.size.y - (box.size.y - orangeLine) / 2);
-                    nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+                                 orangeLine + ioMargin * 1.5);
+                    nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
                     nvgRotate(vg, M_PI / 2);
                     nvgText(vg, 0, 0, "Output", NULL);
                     nvgRestore(vg);
                 }
                 rack::Vec ll;
                 ll = ioPortLocation(i == 0, 0);
-                ll.y = orangeLine + ioMargin + 1.5;
+                ll.y = box.size.y - ioMargin - 1.5;
                 ll.x += 24.6721 / 2;
                 nvgFontSize(vg, 11);
-                nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+                nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
                 nvgText(vg, ll.x, ll.y, "L/Mon", NULL);
 
                 ll = ioPortLocation(i == 0, 1);
-                ll.y = orangeLine + ioMargin + 1.5;
+                ll.y = box.size.y - ioMargin - 1.5;
                 ll.x += 24.6721 / 2;
-                nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+                nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
                 nvgText(vg, ll.x, ll.y, "R", NULL);
 
                 ll = ioPortLocation(i == 0, 2);
-                ll.y = orangeLine + ioMargin + 1.5;
+                ll.y = box.size.y - ioMargin - 1.5;
                 ll.x += 24.6721 / 2;
-                nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+                nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
                 nvgText(vg, ll.x, ll.y, "Gain", NULL);
             }
         }
@@ -257,13 +275,13 @@ struct SurgeRackBG : public rack::TransparentWidget {
     rack::Vec ioPortLocation(bool input,
                              int ctrl) { // 0 is L; 1 is R; 2 is gain
         float portX = 24.6721, portY = 24.6721;
-        int x0 = 0;
+        int x0 = 7;
         if (!input)
-            x0 = box.size.x - ioRegionWidth - 2 * ioMargin;
+            x0 = box.size.x - ioRegionWidth - 2 * ioMargin - 7;
 
         int padFromEdge = input ? 17 : 5;
         int xRes = x0 + ioMargin + padFromEdge + (ctrl * (portX + 4));
-        int yRes = box.size.y - 1.5 * ioMargin - portY;
+        int yRes = orangeLine + 1.5 * ioMargin;
 
         return rack::Vec(xRes, yRes);
     }


### PR DESCRIPTION
This diff does a few small things to clean up the plugin
- It updates the surge submodule to 1.6 beta 9
- It deals with the final string cache for effect name
- It adds screws
- It adds a version displayed in the UI
- It lays out the effect name control in a non random way

CLoses #46 Version in the UI
Closes #8 dirty string caches