### PR TITLE
SurgeStorage reads from the plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,16 @@ endif
 
 # Add files to the ZIP package when running `make dist`
 # The compiled plugin is automatically added.
-DISTRIBUTABLES += $(wildcard LICENSE*) res docs patches README.md
+dist:	build/surge-data
+
+build/surge-data:
+	mkdir -p build/surge-data
+	cp surge/resources/data/configuration.xml build/surge-data
+	cp surge/resources/data/windows.wt build/surge-data
+	cp -R surge/resources/data/wavetables build/surge-data/wavetables
+	cp -R surge/resources/data/wavetables_3rdparty build/surge-data/wavetables_3rdparty
+
+DISTRIBUTABLES += $(wildcard LICENSE*) res docs patches README.md build/surge-data
 
 # Include the VCV plugin Makefile framework
 include $(RACK_DIR)/plugin.mk
@@ -184,7 +193,7 @@ dbg:	dist
 	(cd ~/dev/VCVRack/V1/Rack && make && lldb -- ./Rack -d)
 
 # Special target since we don't have zip on azure (fix this later)
-win-dist: all
+win-dist: all build/surge-data
 	rm -rf dist
 	mkdir -p dist/$(SLUG)
 	@# Strip and copy plugin binary

--- a/scripts/g1.sh
+++ b/scripts/g1.sh
@@ -10,4 +10,13 @@ if [ ! -f build/rack1.info ]; then
 	echo date > build/rack1.info
 fi
 
-RACK_DIR=${RACK_DIR} make -j 4 -k go
+RACK_DIR=${RACK_DIR} make -j 4 -k dist
+cp dist/SurgeRack-1.0.0-mac.zip ${RACK_DIR}/plugins
+pushd ${RACK_DIR}/plugins
+rm -rf SurgeRack
+unzip SurgeRack-1.0.0-mac.zip
+cd ${RACK_DIR}
+ls ./plugins/SurgeRack/surge-data
+make run
+popd
+

--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -96,8 +96,16 @@ template <typename TBase> struct SurgeFX : virtual TBase {
             paramDisplayCache[i] = "";
             paramDisplayDirty[i] = "";
         }
+
+        std::string dataPath;
+#if RACK_V1
+        dataPath = rack::asset::plugin( pluginInstance, "surge-data/" );
+#else
+        dataPath = "";
+#endif
+        
         // TODO: Have a mode where these paths come from res/
-        storage.reset(new SurgeStorage());
+        storage.reset(new SurgeStorage(dataPath));
         INFO("Storage datapath is: %s", storage->datapath.c_str());
 
         // FIX THIS of course


### PR DESCRIPTION
SurgeStorage reads configuration.xml and wavetables from
the plugin zip now, not from the surge install you happen
to have.

Closes #25