### PR TITLE
Do some refactors now I have two modules

### DIFF
--- a/src/SurgeADSR.cpp
+++ b/src/SurgeADSR.cpp
@@ -3,7 +3,7 @@
 #include "SurgeRackGUI.hpp"
 
 struct SurgeADSRWidget : rack::ModuleWidget {
-    typedef SurgeADSR<rack::Module> M;
+    typedef SurgeADSR M;
     SurgeADSRWidget(M *module);
 };
 
@@ -19,8 +19,6 @@ SurgeADSRWidget::SurgeADSRWidget(SurgeADSRWidget::M *module)
 
     box.size = rack::Vec(SCREW_WIDTH * 8, RACK_HEIGHT);
     SurgeRackBG *bg = new SurgeRackBG(rack::Vec(0, 0), box.size, "SurgeEnv");
-    bg->hasInput = false;
-    bg->hasOutput = false;
     addChild(bg);
 
     addInput(rack::createInput<rack::PJ301MPort>(rack::Vec(15,15),
@@ -35,16 +33,6 @@ SurgeADSRWidget::SurgeADSRWidget(SurgeADSRWidget::M *module)
     int envHeight = 40;
     int x0 = 30;
 
-    int lpos = 0;
-    for( auto a : { "A", "D", "S", "R" } )
-    {
-        LabelWidget *lw = LabelWidget::create(rack::Vec(x0 - 20, lpos * envHeight + envStart ),
-                                              rack::Vec(50, envHeight),
-                                              a );
-        bg->addChild(lw);
-        lpos ++;
-    }
-    
     for( int i=M::A_PARAM; i<= M::R_PARAM; ++i )
     {
         int ipos = i - M::A_PARAM;
@@ -89,5 +77,5 @@ rack::Model *modelSurgeADSR =
     rack::createModel<SurgeADSRWidget::M, SurgeADSRWidget>("SurgeADSR");
 #else
 rack::Model *modelSurgeADSR = rack::createModel<SurgeADSRWidget::M, SurgeADSRWidget>(
-    "Surge Team", "SurgeRack", "SurgeADSR", rack::ENVELOPE_GENERATOR_TAG);
+    "Surge Team", "SurgeADSR", "SurgeADSR", rack::ENVELOPE_GENERATOR_TAG);
 #endif

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -1,0 +1,110 @@
+#pragma once
+#include "Surge.hpp"
+#include "rack.hpp"
+#include "SurgeStorage.h"
+
+struct SurgeModuleCommon : virtual public rack::Module
+{
+#if RACK_V1    
+    SurgeModuleCommon() : rack::Module() {
+    }
+#else
+    SurgeModuleCommon(int NUM_P, int NUM_I, int NUM_O, int NUM_L) : rack::Module(NUM_P,NUM_I,NUM_O,NUM_L) {
+        
+        if( this->params.size() == 0)
+        {
+            // FIXME - for some reason the base class constructor isn't called reliably through the templates in V6
+            this->params.resize(NUM_P);
+            this->inputs.resize(NUM_I);
+            this->outputs.resize(NUM_O);
+            this->lights.resize(NUM_L);
+
+        }
+    }
+#endif    
+
+    virtual void onSampleRateChange() override {
+#if RACK_V1        
+        float sr = rack::APP->engine->getSampleRate();
+#else
+        float sr = rack::engineGetSampleRate();
+#endif
+        INFO( "Setting SampleRate to %lf", sr );
+        samplerate = sr;
+        dsamplerate = sr;
+        samplerate_inv = 1.0 / sr;
+        dsamplerate_inv = 1.0 / sr;
+        dsamplerate_os = dsamplerate * OSC_OVERSAMPLING;
+        dsamplerate_os_inv = 1.0 / dsamplerate_os;
+        storage->init_tables();
+
+    }
+    
+    void setupSurgeCommon() {
+        std::string dataPath;
+#if RACK_V1
+        dataPath = rack::asset::plugin( pluginInstance, "surge-data/" );
+#else
+        dataPath = "";
+#endif
+
+        INFO( "setupSurgeCommon| SurgeStorage::dataPath = %s", dataPath.c_str() );
+        
+        // TODO: Have a mode where these paths come from res/
+        storage.reset(new SurgeStorage(dataPath));
+        onSampleRateChange();
+        INFO( "setupSurgeCommon| Completed common setion" );
+    }
+
+    inline float getParam(int id) {
+#if RACK_V1
+        return this->params[id].getValue();
+#else
+        return this->params[id].value;
+#endif
+    }
+
+    inline float getInput(int id) {
+#if RACK_V1
+        return this->inputs[id].getVoltage();
+#else
+        return this->inputs[id].value;
+#endif
+    }
+
+    inline void setOutput(int id, float v) {
+#if RACK_V1
+        this->outputs[id].setVoltage(v);
+#else
+        this->outputs[id].value = v;
+#endif
+    }
+
+
+    std::unique_ptr<SurgeStorage> storage;
+};
+
+struct StringCache
+{
+    std::string value;
+    bool dirty;
+    std::function<std::string()> getValue;
+    std::function<bool()> getDirty;
+
+    StringCache() {
+        value = "";
+        dirty = true;
+        getValue = [this]() { return this->value; };
+        getDirty = [this]() {
+            auto res = dirty;
+            dirty = false;
+            return res;
+        };
+    }
+
+    void reset(std::string s) {
+        value = s;
+        dirty = true;
+    }
+};
+        


### PR DESCRIPTION
This is a technical diff which came from having two modules and
wanting to reduce copied code. There's more to come but

1. Ripped out the TBase stuff which doesn't apply here like it does
   in BaconPlugs
2. Add a common base class for modules
3. Add a background draw hook
4. Add a string cache helper and use it once (but not everywhere) in FX
5. etc...

Closes #56 although I'm sure there's lots more to do...