### PR TITLE
Three core performance improvements

### DIFF
--- a/src/SurgeADSR.hpp
+++ b/src/SurgeADSR.hpp
@@ -75,6 +75,8 @@ struct SurgeADSR : virtual public SurgeModuleCommon {
         adsrstorage->a_s.val.i = 0;
         adsrstorage->d_s.val.i = 0;
         adsrstorage->r_s.val.i = 0;
+
+        setupStorageRanges(&(adsrstorage->a), &(adsrstorage->mode));
     }
 
     std::unique_ptr<AdsrEnvelope> surge_envelope;
@@ -113,7 +115,7 @@ struct SurgeADSR : virtual public SurgeModuleCommon {
         adsrstorage->s.set_value_f01(getParam(S_PARAM) + getInput(S_CV) / 10.0);
         adsrstorage->r.set_value_f01(getParam(R_PARAM) + getInput(R_CV) / 10.0);
 
-        storage->getPatch().copy_scenedata(storage->getPatch().scenedata[0], 0);
+        copyScenedataSubset(0, storage_id_start, storage_id_end);
         surge_envelope->process_block();
 
         setOutput(OUTPUT_ENV, surge_envelope->get_output() * 10.0);

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -82,7 +82,55 @@ struct SurgeModuleCommon : virtual public rack::Module {
 #endif
     }
 
+    inline bool inputConnected(int id) {
+#if RACK_V1
+        return this->inputs[id].isConnected();
+#else
+        return this->inputs[id].active;
+#endif        
+    }
+
+    inline bool outputConnected(int id) {
+#if RACK_V1
+        return this->outputs[id].isConnected();
+#else
+        return this->outputs[id].active;
+#endif        
+    }
+
+    void copyScenedataSubset(int scene, int start, int end) {
+        int s = storage->getPatch().scene_start[scene];
+        for(int i=start; i<end; ++i )
+        {
+            storage->getPatch().scenedata[scene][i-s].i =
+                storage->getPatch().param_ptr[i]->val.i;
+        }
+    }
+
+    void copyGlobaldataSubset(int start, int end) {
+        for(int i=start; i<end; ++i )
+        {
+            storage->getPatch().globaldata[i].i =
+                storage->getPatch().param_ptr[i]->val.i;
+        }
+    }
+
+    void setupStorageRanges(Parameter *start, Parameter *endIncluding) {
+        int min_id = 100000, max_id = -1;
+        Parameter *oap = start;
+        while( oap <= endIncluding )
+        {
+            if( oap->id > max_id ) max_id = oap->id;
+            if( oap->id < min_id ) min_id = oap->id;
+            oap++;
+        }
+
+        storage_id_start = min_id;
+        storage_id_end = max_id + 1;        
+    }
+    
     std::unique_ptr<SurgeStorage> storage;
+    int storage_id_start, storage_id_end;
 };
 
 struct StringCache {


### PR DESCRIPTION
1: For processors which have block sizes, only update the
   parameters when we calculate a block, not on every step
2: For processors using surge storage, only copy the necessary
   subset of params from local to buffer, not the entire scene or
   global set.
3: Don't run the oscillator if you don't have anything connected
   to the output

Closes #73
Closes #80