### PR TITLE
FX Label Invalidation

### DIFF
--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -27,8 +27,8 @@ struct SurgeFX : virtual SurgeModuleCommon {
     enum OutputIds { OUTPUT_R_OR_MONO, OUTPUT_L, NUM_OUTPUTS };
     enum LightIds { NUM_LIGHTS };
 
-    float paramCache[NUM_FX_PARAMS];
-
+    ParamCache pc;
+    
     StringCache paramDisplayCache[NUM_FX_PARAMS];
 
     std::string effectNameCache = "";
@@ -61,10 +61,8 @@ struct SurgeFX : virtual SurgeModuleCommon {
 #endif
 
     void setupSurge() {
-        for (auto i = 0; i < NUM_FX_PARAMS; ++i) {
-            paramCache[i] = -1;
-        }
-
+        pc.resize(NUM_PARAMS);
+        
         setupSurgeCommon();
 
         fxstorage = &(storage->getPatch().fx[0]);
@@ -161,7 +159,6 @@ struct SurgeFX : virtual SurgeModuleCommon {
         }
 
         for (auto i = 0; i < NUM_FX_PARAMS; ++i) {
-            paramCache[i] = -1;
             paramDisplayCache[i].reset("");
         }
     }
@@ -210,16 +207,17 @@ struct SurgeFX : virtual SurgeModuleCommon {
             }
             
             for (int i = 0; i < n_fx_params; ++i) {
-                if (getParam(FX_PARAM_0 + i) != paramCache[i]) {
+                if(pc.changed(FX_PARAM_0 + i, this))
+                {
                     fxstorage->p[orderToParam[i]].set_value_f01(
                         getParam(FX_PARAM_0 + i));
                     char txt[256];
                     fxstorage->p[orderToParam[i]].get_display(txt, false, 0);
                     
                     paramDisplayCache[i].reset(txt);
-                    paramCache[i] = getParam(FX_PARAM_0 + 1);
                 }
             }
+            pc.update(this);
 
             for (int i = 0; i < n_fx_params; ++i) {
                 fxstorage->p[orderToParam[i]].set_value_f01(

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -181,4 +181,7 @@ struct ParamCache {
         }
     }
     float get(int i) { return cache[i]; }
+
+    bool changed(int i, SurgeModuleCommon *m) { return cache[i] != m->getParam(i); }
+    bool changedInt(int i, SurgeModuleCommon *m) { return (int)cache[i] != (int)m->getParam(i); }
 };


### PR DESCRIPTION
FX Label Invalidation was incorrect, over-invalidating labels
leading to 50% of the processing time in FX being sprintf.
This fixes that problem.

Closes #67