### PR TITLE
Fix a memory error

### DIFF
--- a/src/SurgeLFO.cpp
+++ b/src/SurgeLFO.cpp
@@ -85,12 +85,12 @@ SurgeLFOWidget::SurgeLFOWidget(SurgeLFOWidget::M *module)
                                                    ));
         addChild(TextDisplayLight::create(rack::Vec(3 * padMargin + 2 * SurgeLayout::portX + 2, yPos),
                                           rack::Vec(textAreaWidth, controlHeight - padMargin),
-                                          module ? module->pb[i]->nameCache : StringCache::null(),
+                                          module ? &(module->pb[i]->nameCache) : nullptr,
                                           14, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE, SurgeStyle::surgeOrange()));
 
         addChild(TextDisplayLight::create(rack::Vec(3 * padMargin + 2 * SurgeLayout::portX + 2, yPos),
                                           rack::Vec(textAreaWidth - 2 * padMargin, controlHeight - padMargin),
-                                          module ? module->pb[i]->valCache : StringCache::null(),
+                                          module ? &(module->pb[i]->valCache) : nullptr,
                                           14, NVG_ALIGN_RIGHT | NVG_ALIGN_MIDDLE, SurgeStyle::surgeWhite()));
         
     }

--- a/src/SurgeLFO.hpp
+++ b/src/SurgeLFO.hpp
@@ -96,7 +96,7 @@ struct SurgeLFO : virtual public SurgeModuleCommon {
             pb.push_back(std::shared_ptr<RackSurgeParamBinding>(new RackSurgeParamBinding(p0, i, RATE_CV + (i-RATE_PARAM))));
             p0++;
         }
-           
+        
         setupStorageRanges(&(lfostorage->rate), &(lfostorage->release));
         pc.resize(NUM_PARAMS);
     }

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -163,11 +163,6 @@ struct StringCache {
         dirty = true;
     }
 
-    static StringCache null() {
-        StringCache res;
-        res.reset( "null" );
-        return res;
-    }
 };
 
 struct ParamCache {

--- a/src/SurgeOSC.cpp
+++ b/src/SurgeOSC.cpp
@@ -130,7 +130,7 @@ SurgeOSCWidget::SurgeOSCWidget(SurgeOSCWidget::M *module)
         rack::Vec(padFromEdge + 2 * padMargin + SurgeLayout::surgeRoosterX,
                   SCREW_WIDTH + padMargin),
         rack::Vec(100, SurgeLayout::surgeRoosterY),
-        module ? module->oscNameCache : StringCache::null(),
+        module ? &(module->oscNameCache) : nullptr,
         NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT));
 
     addParam(rack::createParam<SurgeKnobRooster>(

--- a/src/SurgeRackGUI.hpp
+++ b/src/SurgeRackGUI.hpp
@@ -132,12 +132,18 @@ struct TextDisplayLight : public rack::Component
 
     static TextDisplayLight *
     create(rack::Vec pos, rack::Vec size, 
-           const StringCache &sc,
+           const StringCache *sc,
            int fsize = 15,
            int align = NVG_ALIGN_LEFT | NVG_ALIGN_TOP,
            NVGcolor color = nvgRGBA(255, 144, 0, 255)) {
-        return TextDisplayLight::create(pos, size, sc.getValue, sc.getDirty,
-                                        fsize, align, color);
+        if( sc )
+            return TextDisplayLight::create(pos, size, sc->getValue, sc->getDirty,
+                                            fsize, align, color);
+        else
+            return TextDisplayLight::create(pos, size,
+                                            []() { return "null"; },
+                                            []() { return false; },
+                                            fsize, align, color);
     }
 
     void drawChars(NVGcontext *vg) {

--- a/src/SurgeVCF.cpp
+++ b/src/SurgeVCF.cpp
@@ -23,7 +23,6 @@ struct SurgeVCFWidget : rack::ModuleWidget {
         nvgText(vg, 0, 0, "SurgeVCF", NULL );
         nvgText(vg, 0, 22, "Under Construction", NULL);
         nvgRestore(vg);
-        INFO( "DREW BACKGROUND" );
     }
 };
 

--- a/src/SurgeVOC.cpp
+++ b/src/SurgeVOC.cpp
@@ -23,7 +23,6 @@ struct SurgeVOCWidget : rack::ModuleWidget {
         nvgText(vg, 0, 0, "SurgeVOC", NULL );
         nvgText(vg, 0, 22, "Under Construction", NULL);
         nvgRestore(vg);
-        INFO( "DREW BACKGROUND" );
     }
 };
 

--- a/src/SurgeWTOSC.cpp
+++ b/src/SurgeWTOSC.cpp
@@ -23,7 +23,6 @@ struct SurgeWTOSCWidget : rack::ModuleWidget {
         nvgText(vg, 0, 0, "SurgeWTOSC", NULL );
         nvgText(vg, 0, 22, "Under Construction", NULL);
         nvgRestore(vg);
-        INFO( "DREW BACKGROUND" );
     }
 };
 


### PR DESCRIPTION
With my new clever classes I had mis-owned a label cache
when module was null, causing a reliable crash on linux
and a reliable mis-draw in the preview pane on mac.