### PR TITLE
OSC Default Values

### DIFF
--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -66,6 +66,14 @@ struct SurgeModuleCommon : virtual public rack::Module {
 #endif
     }
 
+    inline void setParam(int id, float v) {
+#if RACK_V1
+        this->params[id].setValue(v);
+#else
+        this->params[id].value = v;
+#endif
+    }
+
     inline float getInput(int id) {
 #if RACK_V1
         return this->inputs[id].getVoltage();

--- a/src/SurgeOSC.hpp
+++ b/src/SurgeOSC.hpp
@@ -90,6 +90,7 @@ struct SurgeOSC : virtual public SurgeModuleCommon {
                                   storage->getPatch().scenedata[0]));
         surge_osc->init(72.0);
         surge_osc->init_ctrltypes();
+        surge_osc->init_default_values();
         processPosition = BLOCK_SIZE_OS + 1;
         oscstorage->type.val.i = i;
         for (auto i = 0; i < n_osc_params; ++i) {
@@ -97,7 +98,11 @@ struct SurgeOSC : virtual public SurgeModuleCommon {
             char txt[256];
             oscstorage->p[i].get_display(txt, false, 0);
             paramValueCache[i].reset(txt);
+
+            setParam(OSC_CTRL_PARAM_0 + i, oscstorage->p[i].get_value_f01());
         }
+
+        pc.update(this);
     }
 
     int lastUnison = -1;


### PR DESCRIPTION
When switching between oscillator types, set up the OSC in the
default state upon initialization.

Closes #74