### PR TITLE
Knob Memory and Motion; Better Borders

### DIFF
--- a/src/SurgeADSR.hpp
+++ b/src/SurgeADSR.hpp
@@ -69,6 +69,8 @@ struct SurgeADSR : virtual public SurgeModuleCommon {
     }
 #endif
 
+    virtual std::string getName() override { return "ADSR"; }
+
     virtual void setupSurge() {
         setupSurgeCommon();
 

--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -60,6 +60,8 @@ struct SurgeFX : virtual SurgeModuleCommon {
     }
 #endif
 
+    virtual std::string getName() override { return "FX"; }
+
     void setupSurge() {
         pc.resize(NUM_PARAMS);
         
@@ -111,10 +113,6 @@ struct SurgeFX : virtual SurgeModuleCommon {
 
 
         setupStorageRanges((Parameter *)fxstorage, &(fxstorage->p[n_fx_params-1]));
-                           
-        if (surge_effect.get())
-            INFO("Effect Setup Complete: FX Type 2 is %s",
-                 surge_effect->get_effectname());
     }
 
     void reorderSurgeParams() {
@@ -194,7 +192,6 @@ struct SurgeFX : virtual SurgeModuleCommon {
             if (tp != fxstorage->type.val.i &&
                 tp != 0) // FIXME: Deal with the 0 case
             {
-                INFO("FX Type change to %d", tp);
                 fxstorage->type.val.i = tp;
                 surge_effect.reset(spawn_effect(tp, storage.get(),
                                                 &(storage->getPatch().fx[0]),

--- a/src/SurgeLFO.hpp
+++ b/src/SurgeLFO.hpp
@@ -79,6 +79,7 @@ struct SurgeLFO : virtual public SurgeModuleCommon {
     }
 #endif
 
+    virtual std::string getName() override { return "LFO"; }
     
     virtual void setupSurge() {
         setupSurgeCommon();

--- a/src/SurgeOSC.cpp
+++ b/src/SurgeOSC.cpp
@@ -2,7 +2,7 @@
 #include "Surge.hpp"
 #include "SurgeRackGUI.hpp"
 
-struct SurgeOSCWidget : rack::ModuleWidget {
+struct SurgeOSCWidget : public virtual SurgeModuleWidgetCommon {
     typedef SurgeOSC M;
     SurgeOSCWidget(M *module);
 
@@ -113,12 +113,16 @@ struct SurgeOSCWidget : rack::ModuleWidget {
 };
 
 SurgeOSCWidget::SurgeOSCWidget(SurgeOSCWidget::M *module)
-    : rack::ModuleWidget(
-#ifndef RACK_V1
+    : SurgeModuleWidgetCommon(
+#if !RACK_V1
           module
 #endif
-      ) {
-#ifdef RACK_V1
+      )
+#if !RACK_V1
+    , rack::ModuleWidget(module) // why do I need this gcc? SMWC calls it.
+#endif    
+{
+#if RACK_V1
     setModule(module);
 #endif
 

--- a/src/SurgeRackGUI.hpp
+++ b/src/SurgeRackGUI.hpp
@@ -13,6 +13,43 @@
 #include "widgets.hpp"
 #endif
 
+struct SurgeModuleWidgetCommon : public virtual rack::ModuleWidget {
+#if RACK_V1
+    SurgeModuleWidgetCommon() : rack::ModuleWidget() { }
+#else
+    SurgeModuleWidgetCommon(rack::Module *m) : rack::ModuleWidget(m) { }
+
+    int stepsSinceRefresh = 0;
+    void step() override {
+        /*
+        ** This basically moves the surgesmallknobs if they are invalidated
+        ** which is required in V0.6.2 (but not in V1 where this is done internally
+        ** in the knobs). Since I use a dyn cast to find em, only do it every
+        ** 10 frames or so
+        */
+        if( module && stepsSinceRefresh == 0)
+        {
+            for(auto pw : params )
+            {
+                SurgeSmallKnob *ssk;
+                if( (ssk = dynamic_cast<SurgeSmallKnob *>(pw) ) != nullptr )
+                {
+                    if( ssk->value != module->params[ssk->paramId].value )
+                    {
+                        ssk->setValue(module->params[ssk->paramId].value);
+                    }
+                }
+            }
+        }
+        stepsSinceRefresh ++;
+        if( stepsSinceRefresh >= 10 ) stepsSinceRefresh = 0;
+        
+        ModuleWidget::step();
+    }
+    
+#endif    
+};
+
 /*
 ** FIXME: THis class is dumb and we should remove it
 */

--- a/src/SurgeStyle.cpp
+++ b/src/SurgeStyle.cpp
@@ -95,7 +95,9 @@ void SurgeStyle::drawPanelBackground(NVGcontext *vg, float w, float h,
     nvgFill(vg);
 
     nvgBeginPath(vg);
-    nvgMoveTo(vg, w-1, 0);
+    nvgMoveTo(vg, 0, h );
+    nvgLineTo(vg, 0, 0 );
+    nvgLineTo(vg, w-1, 0 );
     nvgLineTo(vg, w-1, h);
     nvgStrokeColor(vg, SurgeStyle::backgroundDarkGray());
     nvgStrokeWidth(vg, 1);
@@ -108,7 +110,9 @@ void SurgeStyle::drawPanelBackground(NVGcontext *vg, float w, float h,
 
     nvgBeginPath(vg);
     nvgMoveTo(vg, w-1, orangeLine);
-    nvgLineTo(vg, w-1, h);
+    nvgLineTo(vg, w-1, h-1);
+    nvgLineTo(vg, 0, h-1 );
+    nvgLineTo(vg, 0, orangeLine );
     nvgStrokeColor(vg, SurgeStyle::surgeOrangeMedium() );
     nvgStrokeWidth(vg, 1);
     nvgStroke(vg);
@@ -119,28 +123,6 @@ void SurgeStyle::drawPanelBackground(NVGcontext *vg, float w, float h,
     nvgStrokeColor(vg, SurgeStyle::surgeBlue());
     nvgStrokeWidth(vg, 1);
     nvgStroke(vg);
-
-    nvgBeginPath(vg);
-    nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
-    nvgFillColor(vg, SurgeStyle::surgeWhite());
-    nvgFontFaceId(vg, fontId);
-    nvgFontSize(vg, 9);
-
-    char version[1024];
-    snprintf(version, 1023, "%s: %s.%s.%s",
-#if WINDOWS
-             "win",
-#endif
-#if MAC
-             "macos",
-#endif
-#if LINUX
-             "linux",
-#endif
-             TOSTRING(SURGE_RACK_BASE_VERSION),
-             TOSTRING(SURGE_RACK_PLUG_VERSION),
-             TOSTRING(SURGE_RACK_SURGE_VERSION));
-    nvgText(vg, w / 2, h - 2, version, NULL);
 
     auto logoSvg = SurgeInternal::getSurgeLogo(false);
     float logoX0 = w / 2;

--- a/src/SurgeVCF.hpp
+++ b/src/SurgeVCF.hpp
@@ -31,7 +31,8 @@ struct SurgeVCF : virtual public SurgeModuleCommon {
     }
 #endif
 
-
+    virtual std::string getName() override { return "VCF"; }
+    
     virtual void setupSurge() {
         setupSurgeCommon();
     }

--- a/src/SurgeVOC.hpp
+++ b/src/SurgeVOC.hpp
@@ -31,6 +31,7 @@ struct SurgeVOC : virtual public SurgeModuleCommon {
     }
 #endif
 
+    virtual std::string getName() override { return "VOC"; }
 
     virtual void setupSurge() {
         setupSurgeCommon();

--- a/src/SurgeWTOSC.hpp
+++ b/src/SurgeWTOSC.hpp
@@ -31,6 +31,7 @@ struct SurgeWTOSC : virtual public SurgeModuleCommon {
     }
 #endif
 
+    virtual std::string getName() override { return "WTOSC"; }
 
     virtual void setupSurge() {
         setupSurgeCommon();

--- a/src/SurgeWaveShaper.hpp
+++ b/src/SurgeWaveShaper.hpp
@@ -25,6 +25,8 @@ struct SurgeWaveShaper : virtual public SurgeModuleCommon {
     }
 #endif
 
+    virtual std::string getName() override { return "WS"; }
+    
     ParamCache pc;
     StringCache wsNameCache, dbGainCache;
     std::vector<std::string> wsNames;


### PR DESCRIPTION
This commit does two big things

1: It adds knob memory per oscillator type, adjusts knobs as
   you switch, detects if you are unstreaming from json to
   override defaults, moves knobs in v0.6.2 etc...

2: Takes the debug version info off the front panel and puts it
   in the log; adds a getName to every SurgeModuleCommon