### PR TITLE
INFO definition changed in v1

### DIFF
--- a/src/Surge.hpp
+++ b/src/Surge.hpp
@@ -8,6 +8,7 @@
 #ifndef RACK_V1
 #define INFO(format, ...)                                                      \
     loggerLog(rack::INFO_LEVEL, __FILE__, __LINE__, format, ##__VA_ARGS__)
+#else
 #endif
 
 extern rack::Plugin *pluginInstance;

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -11,6 +11,10 @@
 #include <map>
 #include <vector>
 
+#if RACK_V1
+namespace logger = rack::logger;
+#endif
+
 struct SurgeModuleCommon : virtual public rack::Module {
 #if RACK_V1
     SurgeModuleCommon() : rack::Module() {  }

--- a/src/SurgeWidgets.cpp
+++ b/src/SurgeWidgets.cpp
@@ -4,6 +4,10 @@
 #include <execinfo.h>
 #endif
 
+#if RACK_V1
+namespace logger = rack::logger;
+#endif
+
 void stackToInfo()
 {
 #if MAC

--- a/src/UserInteractionsRack.cpp
+++ b/src/UserInteractionsRack.cpp
@@ -2,9 +2,7 @@
 #include "rack.hpp"
 #include <sstream>
 
-#ifndef RACK_V1
 using namespace rack;
-#endif
 
 namespace Surge {
 namespace UserInteractions {


### PR DESCRIPTION
This handles INFO refering to logger::log rather than rack::logger::log.
https://github.com/VCVRack/Rack/issues/1276

Closes #119