### PR TITLE
Add -pthread on linux for v1-gpl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ endif
 
 ifdef ARCH_LIN
 SOURCES += surge/src/linux/ConfigurationXml.S
-LDFLAGS += -lstdc++fs
+LDFLAGS += -lstdc++fs -pthread
 
 # This is really a hack but...
 build/surge/src/linux/ConfigurationXml.S.o: surge/src/linux/ConfigurationXml.S


### PR DESCRIPTION
v1-gpl reqires -pthread for modules explicitly now. Adjust. Closes issue #122