### PR TITLE
Implement Presets

### DIFF
--- a/res/presets/OSC/Init_Classic.vcvm
+++ b/res/presets/OSC/Init_Classic.vcvm
@@ -1,0 +1,55 @@
+{
+  "plugin": "SurgeRack",
+  "version": "0.6.0",
+  "model": "SurgeOSC",
+  "params": [
+    {
+      "paramId": 0,
+      "value": 1.0
+    },
+    {
+      "paramId": 1,
+      "value": 0.0
+    },
+    {
+      "paramId": 2,
+      "value": 60.0
+    },
+    {
+      "paramId": 3,
+      "value": 0.0
+    },
+    {
+      "paramId": 4,
+      "value": 0.5
+    },
+    {
+      "paramId": 5,
+      "value": 0.5
+    },
+    {
+      "paramId": 6,
+      "value": 0.5
+    },
+    {
+      "paramId": 7,
+      "value": 7.14061731e-13
+    },
+    {
+      "paramId": 8,
+      "value": 6.9855993e-14
+    },
+    {
+      "paramId": 9,
+      "value": 0.200000003
+    },
+    {
+      "paramId": 10,
+      "value": 0.00102848304
+    }
+  ],
+  "data": {
+    "comment": "No Comment",
+    "buildVersion": "linux: 0.6-alpha.552d214.4555eb7"
+  }
+}

--- a/res/presets/OSC/Init_FM2.vcvm
+++ b/res/presets/OSC/Init_FM2.vcvm
@@ -1,0 +1,55 @@
+{
+  "plugin": "SurgeRack",
+  "version": "0.6.0",
+  "model": "SurgeOSC",
+  "params": [
+    {
+      "paramId": 0,
+      "value": 1.0
+    },
+    {
+      "paramId": 1,
+      "value": 2.0
+    },
+    {
+      "paramId": 2,
+      "value": 60.0
+    },
+    {
+      "paramId": 3,
+      "value": 0.0
+    },
+    {
+      "paramId": 4,
+      "value": 0.0
+    },
+    {
+      "paramId": 5,
+      "value": 1.39668123e-17
+    },
+    {
+      "paramId": 6,
+      "value": 0.0
+    },
+    {
+      "paramId": 7,
+      "value": 0.00499999989
+    },
+    {
+      "paramId": 8,
+      "value": 0.5
+    },
+    {
+      "paramId": 9,
+      "value": 0.0
+    },
+    {
+      "paramId": 10,
+      "value": 1.73774395e-22
+    }
+  ],
+  "data": {
+    "comment": "No Comment",
+    "buildVersion": "linux: 0.6-alpha.552d214.4555eb7"
+  }
+}

--- a/res/presets/OSC/Init_FM3.vcvm
+++ b/res/presets/OSC/Init_FM3.vcvm
@@ -1,0 +1,55 @@
+{
+  "plugin": "SurgeRack",
+  "version": "0.6.0",
+  "model": "SurgeOSC",
+  "params": [
+    {
+      "paramId": 0,
+      "value": 1.0
+    },
+    {
+      "paramId": 1,
+      "value": 3.0
+    },
+    {
+      "paramId": 2,
+      "value": 60.0
+    },
+    {
+      "paramId": 3,
+      "value": 0.0
+    },
+    {
+      "paramId": 4,
+      "value": 0.0
+    },
+    {
+      "paramId": 5,
+      "value": 0.03125
+    },
+    {
+      "paramId": 6,
+      "value": 0.0
+    },
+    {
+      "paramId": 7,
+      "value": 0.03125
+    },
+    {
+      "paramId": 8,
+      "value": 0.0
+    },
+    {
+      "paramId": 9,
+      "value": 0.461538464
+    },
+    {
+      "paramId": 10,
+      "value": 3.80682084e-22
+    }
+  ],
+  "data": {
+    "comment": "No Comment",
+    "buildVersion": "linux: 0.6-alpha.552d214.4555eb7"
+  }
+}

--- a/res/presets/OSC/Init_Noise.vcvm
+++ b/res/presets/OSC/Init_Noise.vcvm
@@ -1,0 +1,55 @@
+{
+  "plugin": "SurgeRack",
+  "version": "0.6.0",
+  "model": "SurgeOSC",
+  "params": [
+    {
+      "paramId": 0,
+      "value": 1.0
+    },
+    {
+      "paramId": 1,
+      "value": 4.0
+    },
+    {
+      "paramId": 2,
+      "value": 60.0
+    },
+    {
+      "paramId": 3,
+      "value": 0.0
+    },
+    {
+      "paramId": 4,
+      "value": 0.5
+    },
+    {
+      "paramId": 5,
+      "value": 0.5
+    },
+    {
+      "paramId": 6,
+      "value": 0.5
+    },
+    {
+      "paramId": 7,
+      "value": 7.14061731e-13
+    },
+    {
+      "paramId": 8,
+      "value": 6.9855993e-14
+    },
+    {
+      "paramId": 9,
+      "value": 0.150000006
+    },
+    {
+      "paramId": 10,
+      "value": 0.00499999989
+    }
+  ],
+  "data": {
+    "comment": "No Comment",
+    "buildVersion": "linux: 0.6-alpha.552d214.4555eb7"
+  }
+}

--- a/res/presets/OSC/Init_Saw.vcvm
+++ b/res/presets/OSC/Init_Saw.vcvm
@@ -1,0 +1,55 @@
+{
+  "plugin": "SurgeRack",
+  "version": "0.6.0",
+  "model": "SurgeOSC",
+  "params": [
+    {
+      "paramId": 0,
+      "value": 1.0
+    },
+    {
+      "paramId": 1,
+      "value": 0.0
+    },
+    {
+      "paramId": 2,
+      "value": 60.0
+    },
+    {
+      "paramId": 3,
+      "value": 0.0
+    },
+    {
+      "paramId": 4,
+      "value": 0.5
+    },
+    {
+      "paramId": 5,
+      "value": 0.5
+    },
+    {
+      "paramId": 6,
+      "value": 0.5
+    },
+    {
+      "paramId": 7,
+      "value": 7.14061731e-13
+    },
+    {
+      "paramId": 8,
+      "value": 6.9855993e-14
+    },
+    {
+      "paramId": 9,
+      "value": 0.150000006
+    },
+    {
+      "paramId": 10,
+      "value": 9.53299129e-9
+    }
+  ],
+  "data": {
+    "comment": "No Comment",
+    "buildVersion": "linux: 0.6-alpha.552d214.4555eb7"
+  }
+}

--- a/res/presets/OSC/Init_Sine.vcvm
+++ b/res/presets/OSC/Init_Sine.vcvm
@@ -1,0 +1,55 @@
+{
+  "plugin": "SurgeRack",
+  "version": "0.6.0",
+  "model": "SurgeOSC",
+  "params": [
+    {
+      "paramId": 0,
+      "value": 1.0
+    },
+    {
+      "paramId": 1,
+      "value": 1.0
+    },
+    {
+      "paramId": 2,
+      "value": 60.0
+    },
+    {
+      "paramId": 3,
+      "value": 0.0
+    },
+    {
+      "paramId": 4,
+      "value": 0.0
+    },
+    {
+      "paramId": 5,
+      "value": 1.39668123e-17
+    },
+    {
+      "paramId": 6,
+      "value": 0.0
+    },
+    {
+      "paramId": 7,
+      "value": 0.00499999989
+    },
+    {
+      "paramId": 8,
+      "value": 0.5
+    },
+    {
+      "paramId": 9,
+      "value": 0.0
+    },
+    {
+      "paramId": 10,
+      "value": 5.37322774e-19
+    }
+  ],
+  "data": {
+    "comment": "No Comment",
+    "buildVersion": "linux: 0.6-alpha.552d214.4555eb7"
+  }
+}

--- a/res/presets/OSC/Init_Square.vcvm
+++ b/res/presets/OSC/Init_Square.vcvm
@@ -1,0 +1,55 @@
+{
+  "plugin": "SurgeRack",
+  "version": "0.6.0",
+  "model": "SurgeOSC",
+  "params": [
+    {
+      "paramId": 0,
+      "value": 1.0
+    },
+    {
+      "paramId": 1,
+      "value": 0.0
+    },
+    {
+      "paramId": 2,
+      "value": 60.0
+    },
+    {
+      "paramId": 3,
+      "value": 0.0
+    },
+    {
+      "paramId": 4,
+      "value": 3.47872771e-19
+    },
+    {
+      "paramId": 5,
+      "value": 0.5
+    },
+    {
+      "paramId": 6,
+      "value": 0.5
+    },
+    {
+      "paramId": 7,
+      "value": 7.14061731e-13
+    },
+    {
+      "paramId": 8,
+      "value": 6.9855993e-14
+    },
+    {
+      "paramId": 9,
+      "value": 0.150000006
+    },
+    {
+      "paramId": 10,
+      "value": 4.35163239e-9
+    }
+  ],
+  "data": {
+    "comment": "No Comment",
+    "buildVersion": "linux: 0.6-alpha.552d214.4555eb7"
+  }
+}

--- a/scripts/g1.sh
+++ b/scripts/g1.sh
@@ -10,16 +10,18 @@ if [ ! -f build/rack1.info ]; then
 	echo date > build/rack1.info
 fi
 
-RACK_DIR=${RACK_DIR} make -j 4 -k all || exit 2
-cp plugin.dylib ${RACK_DIR}/plugins/SurgeRack
-cd ${RACK_DIR}
+#RACK_DIR=${RACK_DIR} make -j 4 -k all || exit 2
+#cp plugin.dylib ${RACK_DIR}/plugins/SurgeRack
+#cd ${RACK_DIR}
 #lldb -- ./Rack -d 
-./Rack -d 
-exit 0
+#./Rack -d 
+#exit 0
+RACK_DIR=${RACK_DIR} make -j 4 -k dist || exit 2
 cp dist/SurgeRack-1.0.0-mac.zip ${RACK_DIR}/plugins
-pushd ${RACK_DIR}/plugins
+cd ${RACK_DIR}/plugins
 rm -rf SurgeRack
 unzip SurgeRack-1.0.0-mac.zip
 ls ./plugins/SurgeRack/surge-data
-popd
+cd ${RACK_DIR}
+./Rack -d 
 

--- a/src/SurgeADSR.hpp
+++ b/src/SurgeADSR.hpp
@@ -92,6 +92,7 @@ struct SurgeADSR : virtual public SurgeModuleCommon {
 
         setupStorageRanges(&(adsrstorage->a), &(adsrstorage->mode));
         pc.resize(NUM_PARAMS);
+
     }
 
     std::unique_ptr<AdsrEnvelope> surge_envelope;


### PR DESCRIPTION
This commit implements factory preset loading for each module in a
generic way in Rack V1. Basically each module (a SurgeModuleCommon
subclass with a getName()) scans "res/presets/getName()" for presets
at the outset. So preset creation is simply creating that directory
and pushing vcvm files. To get started I included @oddy.o.trax's OSC
inits.

Closes #98 