### PR TITLE
FX stereo corrections

### DIFF
--- a/scripts/g1.sh
+++ b/scripts/g1.sh
@@ -12,10 +12,10 @@ fi
 
 RACK_DIR=${RACK_DIR} make -j 4 -k all || exit 2
 cp plugin.dylib ${RACK_DIR}/plugins/SurgeRack
-# cd ${RACK_DIR}
+cd ${RACK_DIR}
 # lldb -- ./Rack -d 
-# ./Rack -d 
-# exit 0
+./Rack -d 
+exit 0
 RACK_DIR=${RACK_DIR} make -j 4 -k dist || exit 2
 cp dist/SurgeRack-1.0.0-mac.zip ${RACK_DIR}/plugins
 cd ${RACK_DIR}/plugins

--- a/src/SurgeFX.cpp
+++ b/src/SurgeFX.cpp
@@ -119,9 +119,9 @@ SurgeFXWidget<effectType>::SurgeFXWidget(SurgeFXWidget<effectType>::M *module)
     addChild(bg);
 
     addInput(rack::createInput<rack::PJ301MPort>(ioPortLocation(true, 0),
-                                                 module, M::INPUT_R_OR_MONO));
+                                                 module, M::INPUT_L_OR_MONO));
     addInput(rack::createInput<rack::PJ301MPort>(ioPortLocation(true, 1),
-                                                 module, M::INPUT_L));
+                                                 module, M::INPUT_R));
     addParam(rack::createParam<SurgeSmallKnob>(ioPortLocation(true, 2), module,
                                                M::INPUT_GAIN
 #if !RACK_V1
@@ -131,9 +131,9 @@ SurgeFXWidget<effectType>::SurgeFXWidget(SurgeFXWidget<effectType>::M *module)
                                                ));
 
     addOutput(rack::createOutput<rack::PJ301MPort>(
-        ioPortLocation(false, 0), module, M::OUTPUT_R_OR_MONO));
+        ioPortLocation(false, 0), module, M::OUTPUT_L_OR_MONO));
     addOutput(rack::createOutput<rack::PJ301MPort>(ioPortLocation(false, 1),
-                                                   module, M::OUTPUT_L));
+                                                   module, M::OUTPUT_R));
     addParam(rack::createParam<SurgeSmallKnob>(ioPortLocation(false, 2), module,
                                                M::OUTPUT_GAIN
 #if !RACK_V1


### PR DESCRIPTION
1. FX never implemented "or mono" correctly
2. FX had Left and Right backwards

This change corrects both.

Closes #11
Closes #54