### PR TITLE
TempoSync for all effects

### DIFF
--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -136,6 +136,22 @@ struct SurgeModuleCommon : public rack::Module {
 #endif        
 
 
+    float lastBPM = -1, lastClockCV = -100;;
+    inline bool updateBPMFromClockCV(float clockCV, float sampleTime, float sampleRate) {
+        if( clockCV == lastClockCV ) return false;
+
+        lastClockCV = clockCV;
+        float clockTime = powf(2.0f, clockCV);
+        float dPhase = clockTime * sampleTime;
+        float samplesPerBeat = 1.0/dPhase;
+        float secondsPerBeat = samplesPerBeat / sampleRate;
+        float beatsPerMinute = 60.0 / secondsPerBeat;
+        lastBPM = beatsPerMinute;
+
+        storage->temposyncratio = beatsPerMinute / 120.0;
+        storage->temposyncratio_inv = 1.f / storage->temposyncratio;
+        return true;
+    }
 
     inline float getParam(int id) {
 #if RACK_V1

--- a/src/SurgeStyle.hpp
+++ b/src/SurgeStyle.hpp
@@ -121,6 +121,8 @@ struct SurgeStyle {
     static float constexpr surgeKnobY = 24;
     static float constexpr surgeRoosterX = 34;
     static float constexpr surgeRoosterY = 34;
+    static float constexpr surgeSwitchX = 14;
+    static float constexpr surgeSwitchY = 21;
 
     /*
       Overall spacing


### PR DESCRIPTION
This change implements temposync support for the effect route.
The FX generic panel gets a clock input and tempo-sync aware
parameters get a toggle. Works exactly as you'd expect.

Closes #51