### PR TITLE
Add a simple skinny clock

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -71,7 +71,12 @@
 			"description": "The Surge Conditioner",
 			"tags": [ "Effect" ]
 		},
-
+		{
+			"slug": "SurgeClock",
+			"name": "SurgeClock",
+			"description": "A utility clock generator",
+			"tags": [ "Clock Generator" ]
+		},
 		{
 			"slug": "SurgeADSR",
 			"name": "SurgeADSR",

--- a/src/Surge.cpp
+++ b/src/Surge.cpp
@@ -21,6 +21,7 @@ void init(rack::Plugin *p) {
     p->addModel(modelSurgeADSR);
     p->addModel(modelSurgeOSC);
     p->addModel(modelSurgeWaveShaper);
+    p->addModel(modelSurgeClock);
     p->addModel(modelSurgeWTOSC);
     p->addModel(modelSurgeVCF);
     p->addModel(modelSurgeLFO);

--- a/src/Surge.hpp
+++ b/src/Surge.hpp
@@ -21,6 +21,7 @@ extern std::set<rack::Model *> modelSurgeFXSet;
 extern rack::Model *modelSurgeADSR;
 extern rack::Model *modelSurgeOSC;
 extern rack::Model *modelSurgeWaveShaper;
+extern rack::Model *modelSurgeClock;
 extern rack::Model *modelSurgeWTOSC;
 extern rack::Model *modelSurgeVCF;
 extern rack::Model *modelSurgeLFO;

--- a/src/SurgeClock.cpp
+++ b/src/SurgeClock.cpp
@@ -1,0 +1,130 @@
+#include "SurgeClock.hpp"
+#include "Surge.hpp"
+#include "SurgeRackGUI.hpp"
+
+struct SurgeClockWidget : SurgeModuleWidgetCommon {
+    typedef SurgeClock M;
+    SurgeClockWidget(M *module);
+
+    int labelHeight = 13;
+
+    float bpmKnob = 50;
+    float textHeight = 16;
+    
+    float pwmKnob = bpmKnob + 3 * padMargin + surgeRoosterY + 2 * textHeight + 20;
+    
+    int topOfInput = RACK_HEIGHT - 5 * padMargin - 3 * labelHeight - 2 * portY + textHeight;
+    
+    void addLabel(NVGcontext *vg, int yp, const char *label,
+                  NVGcolor col = surgeBlue()) {
+        nvgBeginPath(vg);
+        nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+        nvgFontFaceId(vg, fontId(vg));
+        nvgFontSize(vg, 12);
+        nvgFillColor(vg, col);
+        nvgText(vg, box.size.x / 2, yp, label, NULL);
+    }
+    void moduleBackground(NVGcontext *vg) {
+        float yPos;
+
+        addLabel(vg, bpmKnob, "BPM" );
+        drawTextBGRect(vg, padMargin, bpmKnob + 2 * padMargin + textHeight + surgeRoosterY,
+                       box.size.x - 2 * padMargin, textHeight );
+
+        addLabel(vg, pwmKnob, "GatePW" );
+        drawTextBGRect(vg, padMargin, pwmKnob + 2 * padMargin + textHeight + surgeRoosterY,
+                       box.size.x - 2 * padMargin, textHeight );
+        
+        yPos = topOfInput;
+        float sz = ( portY + 2 * padMargin ) / 2;
+        drawBlueIORect(vg, box.size.x / 2 - sz, yPos, sz * 2,
+                                   2 * portY + 2 * labelHeight +
+                                       4 * padMargin);
+        yPos += padMargin;
+        addLabel(vg, yPos, "CV", surgeWhite());
+        yPos += labelHeight + portY + padMargin;
+        addLabel(vg, yPos, "Gate", surgeWhite());
+    }
+};
+
+SurgeClockWidget::SurgeClockWidget(SurgeClockWidget::M *module)
+#ifndef RACK_V1
+    : SurgeModuleWidgetCommon( module ), rack::ModuleWidget( module )
+#else
+    : SurgeModuleWidgetCommon()
+#endif      
+{
+#ifdef RACK_V1
+    setModule(module);
+#endif
+
+    box.size = rack::Vec(SCREW_WIDTH * 3, RACK_HEIGHT);
+    topOfInput = box.size.y - 5 * padMargin - 3 * labelHeight - 2 * portY;
+
+    SurgeRackBG *bg = new SurgeRackBG(rack::Vec(0, 0), box.size, "CLK");
+    bg->narrowMode = true;
+    bg->moduleSpecificDraw = [this](NVGcontext *vg) {
+        this->moduleBackground(vg);
+    };
+    addChild(bg);
+
+    float yPos;
+
+    addParam(rack::createParam<SurgeKnobRooster>(
+        rack::Vec(box.size.x / 2 - surgeRoosterX / 2, bpmKnob + textHeight + padMargin),
+        module, M::CLOCK_CV
+#if !RACK_V1
+        ,
+        -2, 6, 1
+#endif
+        ));
+
+    addChild(TextDisplayLight::create(
+                 rack::Vec(padFromEdge, bpmKnob + textHeight + 2 * padMargin + surgeRoosterY ),
+                 rack::Vec(box.size.x - 2 * padFromEdge, textHeight),
+                 module ? &(module->bpmCache) : nullptr,
+                 11,
+                 NVG_ALIGN_MIDDLE | NVG_ALIGN_CENTER,
+                 surgeWhite()
+                 ));
+
+    addParam(rack::createParam<SurgeKnobRooster>(
+        rack::Vec(box.size.x / 2 - surgeRoosterX / 2, pwmKnob + textHeight + padMargin),
+        module, M::PULSE_WIDTH
+#if !RACK_V1
+        ,
+        0.01, 0.99, 0.5
+#endif
+        ));
+
+    addChild(TextDisplayLight::create(
+                 rack::Vec(padFromEdge, pwmKnob + textHeight + 2 * padMargin + surgeRoosterY ),
+                 rack::Vec(box.size.x - 2 * padFromEdge, textHeight),
+                 module ? &(module->pwCache) : nullptr,
+                 11,
+                 NVG_ALIGN_MIDDLE | NVG_ALIGN_CENTER,
+                 surgeWhite()
+                 ));
+
+
+    yPos = topOfInput;
+    yPos += labelHeight + padMargin;
+    addOutput(rack::createOutput<rack::PJ301MPort>(
+        rack::Vec(box.size.x / 2 - portX / 2, yPos), module,
+        M::CLOCK_CV_OUT));
+    yPos += portY + labelHeight + 2 * padMargin;
+    addOutput(rack::createOutput<rack::PJ301MPort>(
+        rack::Vec(box.size.x / 2 - portX / 2, yPos), module,
+        M::GATE_OUT));
+}
+
+#if RACK_V1
+rack::Model *modelSurgeClock =
+    rack::createModel<SurgeClockWidget::M, SurgeClockWidget>(
+        "SurgeClock");
+#else
+rack::Model *modelSurgeClock =
+    rack::createModel<SurgeClockWidget::M, SurgeClockWidget>(
+        "Surge Team", "SurgeClock", "SurgeClock",
+        rack::ENVELOPE_GENERATOR_TAG);
+#endif

--- a/src/SurgeClock.hpp
+++ b/src/SurgeClock.hpp
@@ -1,0 +1,67 @@
+#pragma once
+#include "Surge.hpp"
+#include "SurgeModuleCommon.hpp"
+#include "rack.hpp"
+#include <cstring>
+
+struct SurgeClock : virtual public SurgeModuleCommon {
+    enum ParamIds { CLOCK_CV, PULSE_WIDTH, NUM_PARAMS };
+    enum InputIds { NUM_INPUTS };
+    enum OutputIds { CLOCK_CV_OUT, GATE_OUT, NUM_OUTPUTS };
+    enum LightIds { NUM_LIGHTS };
+
+#if RACK_V1
+    SurgeClock() : SurgeModuleCommon() {
+        config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
+        configParam(CLOCK_CV, -2, 6, 1);
+        configParam(PULSE_WIDTH, 0.01, 0.99, 0.5);
+    }
+#else
+    SurgeClock()
+        : SurgeModuleCommon(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS) {
+    }
+#endif
+
+    virtual std::string getName() override { return "CLOCK"; }
+    
+    StringCache bpmCache, pwCache;
+
+    float phase = 0;
+    float lastPulse = -1;
+
+#if RACK_V1
+    void process(const typename rack::Module::ProcessArgs &args) override
+#else
+    void step() override
+#endif
+    {
+        bool newBPM = false;
+#if RACK_V1                
+        newBPM = updateBPMFromClockCV(getParam(CLOCK_CV), args.sampleTime, args.sampleRate );
+#else
+        newBPM = updateBPMFromClockCV(getParam(CLOCK_CV), rack::engineGetSampleTime(), rack::engineGetSampleRate() );
+#endif
+        if( newBPM )
+        {
+            char txt[256];
+            snprintf(txt, 256, "%5.1lf", lastBPM );
+            bpmCache.reset(txt);
+        }
+
+        if( getParam(PULSE_WIDTH) != lastPulse )
+        {
+            lastPulse = getParam(PULSE_WIDTH);
+            char txt[256];
+            snprintf(txt, 256, "%5.3lf", getParam(PULSE_WIDTH));
+            pwCache.reset(txt);
+        }
+        
+        phase += dPhase;
+        if( phase > 1 )
+            phase -= 1;
+        float gate = ( phase > getParam(PULSE_WIDTH) ) ? 0 : 10;
+
+        setOutput(CLOCK_CV_OUT,getParam(CLOCK_CV));
+        setOutput(GATE_OUT, gate);
+    }
+};

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -136,20 +136,24 @@ struct SurgeModuleCommon : public rack::Module {
 #endif        
 
 
-    float lastBPM = -1, lastClockCV = -100;;
+    float lastBPM = -1, lastClockCV = -100;
+    float dPhase = 0;
     inline bool updateBPMFromClockCV(float clockCV, float sampleTime, float sampleRate) {
         if( clockCV == lastClockCV ) return false;
 
         lastClockCV = clockCV;
         float clockTime = powf(2.0f, clockCV);
-        float dPhase = clockTime * sampleTime;
+        dPhase = clockTime * sampleTime;
         float samplesPerBeat = 1.0/dPhase;
         float secondsPerBeat = samplesPerBeat / sampleRate;
         float beatsPerMinute = 60.0 / secondsPerBeat;
         lastBPM = beatsPerMinute;
 
-        storage->temposyncratio = beatsPerMinute / 120.0;
-        storage->temposyncratio_inv = 1.f / storage->temposyncratio;
+        if( storage.get() )
+        {
+            storage->temposyncratio = beatsPerMinute / 120.0;
+            storage->temposyncratio_inv = 1.f / storage->temposyncratio;
+        }
         return true;
     }
 


### PR DESCRIPTION
It's useful to have a widget which generates both a gate and
a consistent CV for a clock. So add one in surge even though
it isn't really surge-y