### PR TITLE
Restore windows operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ endif
 
 ifdef ARCH_WIN
 SOURCES += $(SRL)/filesystem/filesystem.cpp
+LDFLAGS += -lWinmm
 endif
 
 ifdef ARCH_LIN

--- a/scripts/buildutil.sh
+++ b/scripts/buildutil.sh
@@ -68,6 +68,11 @@ run_rack()
     fi
 }
 
+clean()
+{
+    RACK_DIR=$RACK_INSTALL_DIR/Rack-SDK make clean
+}
+
 build_surge()
 {
     RACK_DIR=$RACK_INSTALL_DIR/Rack-SDK make -j 4 all
@@ -118,6 +123,9 @@ case $command in
         install_surge
         run_rack
         ;;
+    --clean)
+	clean
+	;;
     *)
         help_message
         ;;

--- a/src/Surge.cpp
+++ b/src/Surge.cpp
@@ -1,21 +1,38 @@
 #include "Surge.hpp"
+#include "SurgeStorage.h"
 
-std::set<rack::Model *> modelSurgeFXSet;
+rack::Model **fxModels = nullptr;
+int addFX(rack::Model *m, int type)
+{
+   rack::INFO( "[SurgeRack] adding FX %d", type );
+   if( fxModels == nullptr ) {
+     fxModels = new rack::Model *[num_fxtypes];
+     for( auto i=0; i<num_fxtypes; ++i )
+       fxModels[i] = nullptr;
+   }
+   fxModels[type] = m;
+   return type;
+}
 
 rack::Plugin *pluginInstance;
 
 void init(rack::Plugin *p) {
     pluginInstance = p;
+    rack::INFO( "[SurgeRack] init" );
 
-    for( auto m : modelSurgeFXSet )
-        p->addModel(m);
-    
+    p->addModel(modelSurgeClock);
     p->addModel(modelSurgeADSR);
+
     p->addModel(modelSurgeOSC);
     p->addModel(modelSurgeWaveShaper);
-    p->addModel(modelSurgeClock);
+
     p->addModel(modelSurgeWTOSC);
     p->addModel(modelSurgeVCF);
     p->addModel(modelSurgeLFO);
     p->addModel(modelSurgeVOC);
+
+    if( fxModels != nullptr )
+      for( auto i=0; i<num_fxtypes; ++i )
+	if( fxModels[i] != nullptr )
+	  p->addModel(fxModels[i]);
 }

--- a/src/Surge.hpp
+++ b/src/Surge.hpp
@@ -8,13 +8,15 @@
 
 extern rack::Plugin *pluginInstance;
 
-extern std::set<rack::Model *> modelSurgeFXSet;
-
+extern rack::Model *modelSurgeClock;
 extern rack::Model *modelSurgeADSR;
+
 extern rack::Model *modelSurgeOSC;
 extern rack::Model *modelSurgeWaveShaper;
-extern rack::Model *modelSurgeClock;
+
 extern rack::Model *modelSurgeWTOSC;
 extern rack::Model *modelSurgeVCF;
 extern rack::Model *modelSurgeLFO;
 extern rack::Model *modelSurgeVOC;
+
+extern int addFX(rack::Model *, int type);

--- a/src/SurgeFX.cpp
+++ b/src/SurgeFX.cpp
@@ -113,8 +113,8 @@ SurgeFXWidget<effectType>::SurgeFXWidget(SurgeFXWidget<effectType>::M *module)
 }
 
 
-#define CREATE_FX( type, name ) auto v ## type = modelSurgeFXSet.insert( \
-        rack::createModel<SurgeFXWidget< type >::M, SurgeFXWidget< type >>(name));
+#define CREATE_FX( type, name ) auto v ## type = addFX( \
+     rack::createModel<SurgeFXWidget< type >::M, SurgeFXWidget< type >>(name), type);
 
 // FIXME: Eventually each of these get their own panel and this list drops to 0
 CREATE_FX( fxt_delay, "SurgeDelay" );

--- a/src/SurgeFreqShift.cpp
+++ b/src/SurgeFreqShift.cpp
@@ -99,6 +99,5 @@ SurgeFreqShiftWidget::SurgeFreqShiftWidget(SurgeFreqShiftWidget::M *module)
     
 }
 
-
-auto mfreq = modelSurgeFXSet.insert(
-    rack::createModel<SurgeFreqShiftWidget::M, SurgeFreqShiftWidget>("SurgeFreqShift") );
+auto mfreq = addFX(
+		   rack::createModel<SurgeFreqShiftWidget::M, SurgeFreqShiftWidget>("SurgeFreqShift"), fxt_freqshift );

--- a/src/SurgeRotary.cpp
+++ b/src/SurgeRotary.cpp
@@ -111,6 +111,6 @@ SurgeRotaryWidget::SurgeRotaryWidget(SurgeRotaryWidget::M *module)
     
 }
 
+auto mrotary = addFX(
+		     rack::createModel<SurgeRotaryWidget::M, SurgeRotaryWidget>("SurgeRotary"), fxt_rotaryspeaker );
 
-auto mrotary = modelSurgeFXSet.insert(
-    rack::createModel<SurgeRotaryWidget::M, SurgeRotaryWidget>("SurgeRotary") );


### PR DESCRIPTION
The FX clever std::map global blew up on windows since dll
initialization order is random. Fix that with an explicit
call that constructs the data structure I wanted anyway.

Closes #151