### PR TITLE
Azure Pipeline uses VERSION properly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,10 +49,9 @@ jobs:
     displayName: Get Surge SubModule
 
   - bash: |
-      which g++
-      g++ --version
-    displayName: Dump Windows Versions
-    condition: variables.isWindows
+      ./scripts/resetversion.sh
+    displayName: Update Version in plugins.json
+
 
   - bash: |
       export RACK_DIR=$AGENT_TEMPDIRECTORY/Rack-SDK
@@ -123,7 +122,7 @@ jobs:
 
   - bash: |
      ls -l $(Build.ArtifactStagingDirectory)
-     export EXTEND_TAG=`date "+%Y%m%d-%H%M"`-`git rev-parse --short HEAD`
+     export EXTEND_TAG=`date "+%Y%m%d"`
      for file in $(Build.ArtifactStagingDirectory)/*.zip; do mv "$file" "${file/.zip/-${EXTEND_TAG}.zip}"; done
      ls -l $(Build.ArtifactStagingDirectory)         
     displayName: Tag asset names with Date

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
 	"slug": "SurgeRack",
 	"name": "Surge for Rack",
-	"version": "1.0.0",
+	"version": "1.alpha.LOCALBUILD",
 	"license": "GPL3",
 	"author": "The Surge Team",
 	"authorEmail": "",

--- a/scripts/resetversion.sh
+++ b/scripts/resetversion.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+gitrev=`git rev-parse --short HEAD`
+version="1.alpha.${gitrev}"
+echo "Updating to version=$version"
+tf=`mktemp`
+jq --arg VERSION "$version" '.version=$VERSION' plugin.json > $tf
+mv $tf plugin.json
+


### PR DESCRIPTION
The azure pipeline builds kept the VERSION of the built asset
at 1.0.0. This makes it so the version is 1.alpha.githash.