### PR TITLE
Finish WT; Clean up Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ As of May 19, the weekend of the dev release of Rack 1.0, we have stopped suppor
 
 Our overall goal for our first release is to have all the stages exposed as modules which work with an acceptable
 front plate, are full "phase2/3" rack 1.0 modules, but are still monophonic.
-Here's how far we are along on that journey.
+Here's how far we are along on that journey. "Completed" doesn't mean bug free; it means monophonic, clean front
+panel, works as expected except in a couple of edge cases which are documented in github issues.
 
 <table>
 <tr><th>Plugin</th><th>Description</th><th>State</th></tr>
@@ -24,9 +25,9 @@ Here's how far we are along on that journey.
   <td>The surge FX stage is represented as a set of modules, one per effect.</td>
   <td>The modules all work; most have a generic panel still</td></tr>
 <tr><td>SurgeADSR</td><td>The Surge Envelope Generator with digital and analog modes</td><td>Completed</td></tr>
-<tr><td>SurgeOSC</td><td>The Surge non-wavetable Oscillators</td><td>Very good shape. Few pops and clicks when changing osc type or changing unison count, but works well otherwise.</td></tr>
+<tr><td>SurgeOSC</td><td>The Surge non-wavetable Oscillators</td><td>Completed</td></tr>
 <tr><td>SurgeWaveShaper</td><td>The waveshaper stage, including digital, tanh, warmers</td><td>Completed</td></tr>
-<tr><td>SurgeWTOSC</td><td>The WaveTable Oscillator</td><td>Works well; need to fill that UI gap with WT info</td></tr>
+<tr><td>SurgeWTOSC</td><td>The WaveTable Oscillator</td><td>Completed</td></tr>
 <tr><td>SurgeLFO</td><td>The powerful surge LFO</td><td>Works perfectly; terrible UI</td></tr>
 <tr><td>SurgeVCF</td><td>The amazingly amazing Surge Filters</td><td>which don't yet exist in rack</td></tr>
 <tr><td>SurgeVOC</td><td>The surge Vocoder stage</td><td>Completed</td></tr>

--- a/src/Surge.cpp
+++ b/src/Surge.cpp
@@ -4,7 +4,6 @@
 rack::Model **fxModels = nullptr;
 int addFX(rack::Model *m, int type)
 {
-   rack::INFO( "[SurgeRack] adding FX %d", type );
    if( fxModels == nullptr ) {
        fxModels = new rack::Model *[num_fxtypes];
        for( auto i=0; i<num_fxtypes; ++i )

--- a/src/SurgeWTOSC.cpp
+++ b/src/SurgeWTOSC.cpp
@@ -9,6 +9,8 @@ struct SurgeWTOSCWidget : public virtual SurgeModuleWidgetCommon {
     int ioRegionWidth = 105;
 
     float pitchY = SCREW_WIDTH + padFromEdge;
+    float infoPos0 = pitchY + 25 + padMargin;
+    
     float pitchCtrlX = padFromEdge + 2 * padMargin + 2 * portX;
     
     float controlsY = pitchY + 2 * padMargin + surgeRoosterY + portY;
@@ -68,6 +70,11 @@ struct SurgeWTOSCWidget : public virtual SurgeModuleWidgetCommon {
             drawTextBGRect(vg, xp, yp, colOneEnd - padFromEdge - xp, controlHeightPer - padMargin);
         }
 
+        centerRuledLabel( vg, colOneEnd + padFromEdge, infoPos0, box.size.x - colOneEnd - 2 * padFromEdge, "Current WT" );
+        drawTextBGRect( vg, colOneEnd + padFromEdge, infoPos0 + 14 + padMargin,
+                        box.size.x - colOneEnd - 2 * padFromEdge, 50 );
+        
+        
         auto xpf = [this](int i) { return this->colOneEnd + this->catitlodsz * ( i + 0.5 );  };
         std::vector<std::string> cil = { "Cat", "WT", "Load" };
         for( int i=0; i<3; ++i )
@@ -176,6 +183,19 @@ SurgeWTOSCWidget::SurgeWTOSCWidget(SurgeWTOSCWidget::M *module)
     
     addParam(bank);
 
+    for( int i=0; i<3; ++i )
+    {
+        int xp = colOneEnd + padMargin + padFromEdge;
+        int yp = infoPos0 + 14 + padMargin + 2.5 + i * 15;
+        addChild(TextDisplayLight::create(
+                     rack::Vec(xp, yp),
+                     rack::Vec(box.size.x - colOneEnd - 2 * padMargin, 15 ),
+                     module ? &(module->wtInfoCache[i]) : nullptr,
+                     13, NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT, surgeWhite() ));
+
+        
+    }
+    
     auto xpf = [this](int i) { return this->colOneEnd + this->catitlodsz * ( i + 0.5 ) - this->surgeRoosterX / 2.0; };
     
     addParam(rack::createParam<SurgeKnobRooster>(


### PR DESCRIPTION
1. Finish the WT UI by adding information on the wavetable to
   the screen in that big blank space
2. Clean up some of the log messages we didn't need
3. Make the "getVersion" in SurgeModuleCommon the more accurate
   "getBuildInfo" and adjust

Closes #31