### PR TITLE
Support voltage levels correctly

### DIFF
--- a/patches/RotaryExample.vcv
+++ b/patches/RotaryExample.vcv
@@ -1,0 +1,863 @@
+{
+  "version": "1.dev.ddf06a9",
+  "modules": [
+    {
+      "plugin": "Fundamental",
+      "version": "1.0.0",
+      "model": "SEQ3",
+      "params": [
+        {
+          "id": 0,
+          "value": 0.812000155
+        },
+        {
+          "id": 1,
+          "value": 0.0
+        },
+        {
+          "id": 2,
+          "value": 0.0
+        },
+        {
+          "id": 3,
+          "value": 4.0
+        },
+        {
+          "id": 4,
+          "value": 0.200000003
+        },
+        {
+          "id": 5,
+          "value": 0.5
+        },
+        {
+          "id": 6,
+          "value": 1.0
+        },
+        {
+          "id": 7,
+          "value": 0.0
+        },
+        {
+          "id": 8,
+          "value": 0.0
+        },
+        {
+          "id": 9,
+          "value": 0.0
+        },
+        {
+          "id": 10,
+          "value": 0.0
+        },
+        {
+          "id": 11,
+          "value": 0.0
+        },
+        {
+          "id": 12,
+          "value": 0.0
+        },
+        {
+          "id": 13,
+          "value": 0.0
+        },
+        {
+          "id": 14,
+          "value": 0.0
+        },
+        {
+          "id": 15,
+          "value": 0.0
+        },
+        {
+          "id": 16,
+          "value": 0.0
+        },
+        {
+          "id": 17,
+          "value": 0.0
+        },
+        {
+          "id": 18,
+          "value": 0.0
+        },
+        {
+          "id": 19,
+          "value": 0.0
+        },
+        {
+          "id": 20,
+          "value": 0.0
+        },
+        {
+          "id": 21,
+          "value": 0.0
+        },
+        {
+          "id": 22,
+          "value": 0.0
+        },
+        {
+          "id": 23,
+          "value": 0.0
+        },
+        {
+          "id": 24,
+          "value": 0.0
+        },
+        {
+          "id": 25,
+          "value": 0.0
+        },
+        {
+          "id": 26,
+          "value": 0.0
+        },
+        {
+          "id": 27,
+          "value": 0.0
+        },
+        {
+          "id": 28,
+          "value": 0.0
+        },
+        {
+          "id": 29,
+          "value": 0.0
+        },
+        {
+          "id": 30,
+          "value": 0.0
+        },
+        {
+          "id": 31,
+          "value": 0.0
+        },
+        {
+          "id": 32,
+          "value": 0.0
+        },
+        {
+          "id": 33,
+          "value": 0.0
+        },
+        {
+          "id": 34,
+          "value": 0.0
+        },
+        {
+          "id": 35,
+          "value": 0.0
+        }
+      ],
+      "data": {
+        "running": true,
+        "gates": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "leftModuleId": 41,
+      "rightModuleId": 34,
+      "id": 33,
+      "pos": [
+        3,
+        0
+      ]
+    },
+    {
+      "plugin": "SurgeRack",
+      "version": "1.alpha.LOCALBUILD",
+      "model": "SurgeWTOSC",
+      "params": [
+        {
+          "id": 0,
+          "value": 1.0
+        },
+        {
+          "id": 1,
+          "value": 48.0930443
+        },
+        {
+          "id": 2,
+          "value": 0.0
+        },
+        {
+          "id": 3,
+          "value": 0.0
+        },
+        {
+          "id": 4,
+          "value": 0.5
+        },
+        {
+          "id": 5,
+          "value": 0.0
+        },
+        {
+          "id": 6,
+          "value": 0.0
+        },
+        {
+          "id": 7,
+          "value": 0.5
+        },
+        {
+          "id": 8,
+          "value": 0.200000003
+        },
+        {
+          "id": 9,
+          "value": 0.00499999989
+        },
+        {
+          "id": 10,
+          "value": 0.742500365
+        },
+        {
+          "id": 11,
+          "value": 0.138000026
+        },
+        {
+          "id": 12,
+          "value": 0.0
+        },
+        {
+          "id": 13,
+          "value": 0.0
+        }
+      ],
+      "data": {
+        "comment": "No Comment",
+        "buildInfo": "os:macos pluggit:294594a surgegit:b946ee3 buildtime=May 22 2019 16:57:55"
+      },
+      "leftModuleId": 33,
+      "rightModuleId": 40,
+      "id": 34,
+      "pos": [
+        25,
+        0
+      ]
+    },
+    {
+      "plugin": "Core",
+      "version": "1.dev.ddf06a9",
+      "model": "AudioInterface",
+      "params": [],
+      "data": {
+        "audio": {
+          "driver": 5,
+          "deviceName": "Apple Inc.: DisplayPort",
+          "offset": 0,
+          "maxChannels": 8,
+          "sampleRate": 44100,
+          "blockSize": 256
+        }
+      },
+      "leftModuleId": 36,
+      "rightModuleId": 42,
+      "id": 35,
+      "pos": [
+        20,
+        1
+      ]
+    },
+    {
+      "plugin": "Fundamental",
+      "version": "1.0.0",
+      "model": "VCMixer",
+      "params": [
+        {
+          "id": 0,
+          "value": 0.513999701
+        },
+        {
+          "id": 1,
+          "value": 0.0169705618
+        },
+        {
+          "id": 2,
+          "value": 1.0
+        },
+        {
+          "id": 3,
+          "value": 1.0
+        },
+        {
+          "id": 4,
+          "value": 1.0
+        }
+      ],
+      "leftModuleId": 37,
+      "rightModuleId": 35,
+      "id": 36,
+      "pos": [
+        10,
+        1
+      ]
+    },
+    {
+      "plugin": "Fundamental",
+      "version": "1.0.0",
+      "model": "VCMixer",
+      "params": [
+        {
+          "id": 0,
+          "value": 0.501999557
+        },
+        {
+          "id": 1,
+          "value": 0.0254558418
+        },
+        {
+          "id": 2,
+          "value": 1.0
+        },
+        {
+          "id": 3,
+          "value": 1.0
+        },
+        {
+          "id": 4,
+          "value": 1.0
+        }
+      ],
+      "rightModuleId": 36,
+      "id": 37,
+      "pos": [
+        0,
+        1
+      ]
+    },
+    {
+      "plugin": "Fundamental",
+      "version": "1.0.0",
+      "model": "VCA-1",
+      "params": [
+        {
+          "id": 0,
+          "value": 1.0
+        },
+        {
+          "id": 1,
+          "value": 1.0
+        }
+      ],
+      "leftModuleId": 39,
+      "id": 38,
+      "pos": [
+        53,
+        0
+      ]
+    },
+    {
+      "plugin": "Fundamental",
+      "version": "1.0.0",
+      "model": "VCA-1",
+      "params": [
+        {
+          "id": 0,
+          "value": 1.0
+        },
+        {
+          "id": 1,
+          "value": 1.0
+        }
+      ],
+      "leftModuleId": 40,
+      "rightModuleId": 38,
+      "id": 39,
+      "pos": [
+        50,
+        0
+      ]
+    },
+    {
+      "plugin": "SurgeRack",
+      "version": "1.alpha.LOCALBUILD",
+      "model": "SurgeADSR",
+      "params": [
+        {
+          "id": 0,
+          "value": 0.232999846
+        },
+        {
+          "id": 1,
+          "value": 0.518000126
+        },
+        {
+          "id": 2,
+          "value": 0.790999889
+        },
+        {
+          "id": 3,
+          "value": 0.465500057
+        },
+        {
+          "id": 4,
+          "value": 0.0
+        },
+        {
+          "id": 5,
+          "value": 0.0
+        },
+        {
+          "id": 6,
+          "value": 0.0
+        },
+        {
+          "id": 7,
+          "value": 0.0
+        }
+      ],
+      "data": {
+        "comment": "No Comment",
+        "buildInfo": "os:macos pluggit:294594a surgegit:b946ee3 buildtime=May 22 2019 16:57:55"
+      },
+      "leftModuleId": 34,
+      "rightModuleId": 39,
+      "id": 40,
+      "pos": [
+        43,
+        0
+      ]
+    },
+    {
+      "plugin": "SurgeRack",
+      "version": "1.alpha.LOCALBUILD",
+      "model": "SurgeClock",
+      "params": [
+        {
+          "id": 0,
+          "value": 0.172000006
+        },
+        {
+          "id": 1,
+          "value": 0.810170531
+        }
+      ],
+      "data": {
+        "comment": "No Comment",
+        "buildInfo": "os:macos pluggit:294594a surgegit:b946ee3 buildtime=May 22 2019 16:57:55"
+      },
+      "rightModuleId": 33,
+      "id": 41,
+      "pos": [
+        0,
+        0
+      ]
+    },
+    {
+      "plugin": "SurgeRack",
+      "version": "1.alpha.LOCALBUILD",
+      "model": "SurgeRotary",
+      "params": [
+        {
+          "id": 0,
+          "value": 0.521000028
+        },
+        {
+          "id": 1,
+          "value": 0.487000436
+        },
+        {
+          "id": 2,
+          "value": 0.468500793
+        },
+        {
+          "id": 3,
+          "value": 0.0
+        },
+        {
+          "id": 4,
+          "value": 0.0
+        },
+        {
+          "id": 5,
+          "value": 0.0
+        },
+        {
+          "id": 6,
+          "value": 0.0
+        },
+        {
+          "id": 7,
+          "value": 0.0
+        },
+        {
+          "id": 8,
+          "value": 0.0
+        },
+        {
+          "id": 9,
+          "value": 0.0
+        },
+        {
+          "id": 10,
+          "value": 0.0
+        },
+        {
+          "id": 11,
+          "value": 0.0
+        },
+        {
+          "id": 12,
+          "value": 1.0
+        },
+        {
+          "id": 13,
+          "value": 1.0
+        },
+        {
+          "id": 14,
+          "value": 0.0
+        },
+        {
+          "id": 15,
+          "value": 0.0
+        },
+        {
+          "id": 16,
+          "value": 0.0
+        },
+        {
+          "id": 17,
+          "value": 0.0
+        },
+        {
+          "id": 18,
+          "value": 0.0
+        },
+        {
+          "id": 19,
+          "value": 0.0
+        },
+        {
+          "id": 20,
+          "value": 0.0
+        },
+        {
+          "id": 21,
+          "value": 0.0
+        },
+        {
+          "id": 22,
+          "value": 0.0
+        },
+        {
+          "id": 23,
+          "value": 0.0
+        },
+        {
+          "id": 24,
+          "value": 0.0
+        },
+        {
+          "id": 25,
+          "value": 0.0
+        },
+        {
+          "id": 26,
+          "value": 1.0
+        }
+      ],
+      "data": {
+        "comment": "No Comment",
+        "buildInfo": "os:macos pluggit:294594a surgegit:b946ee3 buildtime=May 22 2019 16:57:55"
+      },
+      "leftModuleId": 35,
+      "rightModuleId": 45,
+      "id": 42,
+      "pos": [
+        30,
+        1
+      ]
+    },
+    {
+      "plugin": "SurgeRack",
+      "version": "1.alpha.LOCALBUILD",
+      "model": "SurgeLFO",
+      "params": [
+        {
+          "id": 0,
+          "value": 0.249499917
+        },
+        {
+          "id": 1,
+          "value": 0.0
+        },
+        {
+          "id": 2,
+          "value": 0.0
+        },
+        {
+          "id": 3,
+          "value": 1.0
+        },
+        {
+          "id": 4,
+          "value": 0.5
+        },
+        {
+          "id": 5,
+          "value": 0.0
+        },
+        {
+          "id": 6,
+          "value": 0.0
+        },
+        {
+          "id": 7,
+          "value": 0.0
+        },
+        {
+          "id": 8,
+          "value": 0.100000001
+        },
+        {
+          "id": 9,
+          "value": 0.200000003
+        },
+        {
+          "id": 10,
+          "value": 0.200000003
+        },
+        {
+          "id": 11,
+          "value": 0.699999988
+        },
+        {
+          "id": 12,
+          "value": 0.300000012
+        },
+        {
+          "id": 13,
+          "value": 0.0
+        },
+        {
+          "id": 14,
+          "value": 0.0
+        },
+        {
+          "id": 15,
+          "value": 0.0
+        },
+        {
+          "id": 16,
+          "value": 0.0
+        },
+        {
+          "id": 17,
+          "value": 0.0
+        },
+        {
+          "id": 18,
+          "value": 0.0
+        },
+        {
+          "id": 19,
+          "value": 0.0
+        }
+      ],
+      "data": {
+        "comment": "No Comment",
+        "buildInfo": "os:macos pluggit:294594a surgegit:b946ee3 buildtime=May 22 2019 16:57:55"
+      },
+      "leftModuleId": 45,
+      "id": 44,
+      "pos": [
+        46,
+        1
+      ]
+    },
+    {
+      "plugin": "Fundamental",
+      "version": "1.0.0",
+      "model": "8vert",
+      "params": [
+        {
+          "id": 0,
+          "value": 0.956999898
+        },
+        {
+          "id": 1,
+          "value": -0.981000066
+        },
+        {
+          "id": 2,
+          "value": 0.0
+        },
+        {
+          "id": 3,
+          "value": 0.0
+        },
+        {
+          "id": 4,
+          "value": 0.0
+        },
+        {
+          "id": 5,
+          "value": 0.0
+        },
+        {
+          "id": 6,
+          "value": 0.0
+        },
+        {
+          "id": 7,
+          "value": 0.0
+        }
+      ],
+      "leftModuleId": 42,
+      "rightModuleId": 44,
+      "id": 45,
+      "pos": [
+        38,
+        1
+      ]
+    }
+  ],
+  "id": 23,
+  "cables": [
+    {
+      "outputModuleId": 36,
+      "outputId": 0,
+      "inputModuleId": 35,
+      "inputId": 1,
+      "color": "#c9b70e"
+    },
+    {
+      "outputModuleId": 37,
+      "outputId": 0,
+      "inputModuleId": 35,
+      "inputId": 0,
+      "color": "#0c8e15"
+    },
+    {
+      "outputModuleId": 34,
+      "outputId": 1,
+      "inputModuleId": 38,
+      "inputId": 1,
+      "color": "#c91847"
+    },
+    {
+      "outputModuleId": 34,
+      "outputId": 0,
+      "inputModuleId": 39,
+      "inputId": 1,
+      "color": "#0986ad"
+    },
+    {
+      "outputModuleId": 40,
+      "outputId": 0,
+      "inputModuleId": 39,
+      "inputId": 0,
+      "color": "#c9b70e"
+    },
+    {
+      "outputModuleId": 40,
+      "outputId": 0,
+      "inputModuleId": 38,
+      "inputId": 0,
+      "color": "#0c8e15"
+    },
+    {
+      "outputModuleId": 39,
+      "outputId": 0,
+      "inputModuleId": 37,
+      "inputId": 1,
+      "color": "#0986ad"
+    },
+    {
+      "outputModuleId": 41,
+      "outputId": 1,
+      "inputModuleId": 40,
+      "inputId": 0,
+      "color": "#c91847"
+    },
+    {
+      "outputModuleId": 41,
+      "outputId": 1,
+      "inputModuleId": 33,
+      "inputId": 1,
+      "color": "#0c8e15"
+    },
+    {
+      "outputModuleId": 33,
+      "outputId": 1,
+      "inputModuleId": 34,
+      "inputId": 0,
+      "color": "#c91847"
+    },
+    {
+      "outputModuleId": 38,
+      "outputId": 0,
+      "inputModuleId": 42,
+      "inputId": 1,
+      "color": "#0986ad"
+    },
+    {
+      "outputModuleId": 39,
+      "outputId": 0,
+      "inputModuleId": 42,
+      "inputId": 0,
+      "color": "#c9b70e"
+    },
+    {
+      "outputModuleId": 38,
+      "outputId": 0,
+      "inputModuleId": 36,
+      "inputId": 1,
+      "color": "#c9b70e"
+    },
+    {
+      "outputModuleId": 42,
+      "outputId": 0,
+      "inputModuleId": 37,
+      "inputId": 2,
+      "color": "#c91847"
+    },
+    {
+      "outputModuleId": 42,
+      "outputId": 1,
+      "inputModuleId": 36,
+      "inputId": 2,
+      "color": "#0986ad"
+    },
+    {
+      "outputModuleId": 44,
+      "outputId": 0,
+      "inputModuleId": 45,
+      "inputId": 0,
+      "color": "#c91847"
+    },
+    {
+      "outputModuleId": 44,
+      "outputId": 0,
+      "inputModuleId": 45,
+      "inputId": 1,
+      "color": "#0986ad"
+    },
+    {
+      "outputModuleId": 45,
+      "outputId": 1,
+      "inputModuleId": 42,
+      "inputId": 4,
+      "color": "#c9b70e"
+    },
+    {
+      "outputModuleId": 45,
+      "outputId": 0,
+      "inputModuleId": 42,
+      "inputId": 3,
+      "color": "#0c8e15"
+    }
+  ]
+}

--- a/src/Surge.hpp
+++ b/src/Surge.hpp
@@ -6,6 +6,20 @@
 #define SCREW_WIDTH 15
 #define RACK_HEIGHT 380
 
+// https://vcvrack.com/manual/VoltageStandards.html
+#define RACK_CV_MAX_LEVEL 10
+#define SURGE_CV_MAX_LEVEL 1
+
+#define RACK_OSC_MAX_LEVEL 5
+#define SURGE_OSC_PEAK_TO_PEAK 2
+#define SURGE_OSC_MAX_LEVEL 1
+
+#define SURGE_TO_RACK_OSC_MUL 5
+#define RACK_TO_SURGE_OSC_MUL 0.2
+
+#define SURGE_TO_RACK_CV_MUL 10
+#define RACK_TO_SURGE_CV_MUL 0.1
+
 extern rack::Plugin *pluginInstance;
 
 extern rack::Model *modelSurgeClock;

--- a/src/SurgeADSR.hpp
+++ b/src/SurgeADSR.hpp
@@ -133,13 +133,13 @@ struct SurgeADSR : virtual public SurgeModuleCommon {
             adsrstorage->r_s.val.i = (int)getParam(R_S_PARAM);
 
             adsrstorage->a.set_value_f01(getParam(A_PARAM) +
-                                         getInput(A_CV) / 10.0);
+                                         getInput(A_CV) * RACK_TO_SURGE_CV_MUL );
             adsrstorage->d.set_value_f01(getParam(D_PARAM) +
-                                         getInput(D_CV) / 10.0);
+                                         getInput(D_CV) * RACK_TO_SURGE_CV_MUL);
             adsrstorage->s.set_value_f01(getParam(S_PARAM) +
-                                         getInput(S_CV) / 10.0);
+                                         getInput(S_CV) * RACK_TO_SURGE_CV_MUL);
             adsrstorage->r.set_value_f01(getParam(R_PARAM) +
-                                         getInput(R_CV) / 10.0);
+                                         getInput(R_CV) * RACK_TO_SURGE_CV_MUL);
 
             copyScenedataSubset(0, storage_id_start, storage_id_end);
             surge_envelope->process_block();

--- a/src/SurgeClock.hpp
+++ b/src/SurgeClock.hpp
@@ -46,7 +46,7 @@ struct SurgeClock : virtual public SurgeModuleCommon {
         phase += dPhase;
         if( phase > 1 )
             phase -= 1;
-        float gate = ( phase > getParam(PULSE_WIDTH) ) ? 0 : 10;
+        float gate = ( phase > getParam(PULSE_WIDTH) ) ? 0 : RACK_CV_MAX_LEVEL;
 
         setOutput(CLOCK_CV_OUT,getParam(CLOCK_CV));
         setOutput(GATE_OUT, gate);

--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -183,8 +183,8 @@ struct SurgeFX : virtual SurgeModuleCommon {
         float outG = getParam(OUTPUT_GAIN);
 
 
-        float inl = inpG * getInput(INPUT_L_OR_MONO) / 10.0;
-        float inr = inpG * getInput(INPUT_R) / 10.0;
+        float inl = inpG * getInput(INPUT_L_OR_MONO) * RACK_TO_SURGE_OSC_MUL;
+        float inr = inpG * getInput(INPUT_R) * RACK_TO_SURGE_OSC_MUL;
 
         if( inputConnected(INPUT_L_OR_MONO) && ! inputConnected(INPUT_R) )
         {
@@ -266,8 +266,7 @@ struct SurgeFX : virtual SurgeModuleCommon {
 
             for (int i = 0; i < n_fx_params; ++i) {
                 fxstorage->p[orderToParam[i]].set_value_f01(
-                    getParam(FX_PARAM_0 + i) + (getInput(FX_PARAM_INPUT_0 + i)) /
-                    10.0 );
+                    getParam(FX_PARAM_0 + i) + (getInput(FX_PARAM_INPUT_0 + i)) * RACK_TO_SURGE_CV_MUL );
             }
 
             copyGlobaldataSubset(storage_id_start, storage_id_end);
@@ -276,8 +275,8 @@ struct SurgeFX : virtual SurgeModuleCommon {
             bufferPos = 0;
         }
 
-        float outl = outG * processedL[bufferPos] * 10;
-        float outr = outG * processedR[bufferPos] * 10;
+        float outl = outG * processedL[bufferPos] * SURGE_TO_RACK_OSC_MUL;
+        float outr = outG * processedR[bufferPos] * SURGE_TO_RACK_OSC_MUL;
 
         if( outputConnected(OUTPUT_L_OR_MONO) && ! outputConnected(OUTPUT_R) )
         {

--- a/src/SurgeLFO.hpp
+++ b/src/SurgeLFO.hpp
@@ -235,6 +235,6 @@ struct SurgeLFO : virtual public SurgeModuleCommon {
         lastStep++;
         float frac = 1.0 * lastStep / BLOCK_SIZE;
         float outputI = output0 * (1.0-frac) + output1 * frac;
-        setOutput(OUTPUT_ENV, outputI * 10.0);
+        setOutput(OUTPUT_ENV, outputI * SURGE_TO_RACK_OSC_MUL);
     }
 };

--- a/src/SurgeOSC.hpp
+++ b/src/SurgeOSC.hpp
@@ -216,7 +216,7 @@ struct SurgeOSC : virtual public SurgeModuleCommon {
             {
                 for (int i = 0; i < n_scene_params; ++i) {
                     oscstorage->p[i].set_value_f01(getParam(OSC_CTRL_PARAM_0 + i) +
-                                                   getInput(OSC_CTRL_CV_0 + i) / 10.0);
+                                                   getInput(OSC_CTRL_CV_0 + i) * RACK_TO_SURGE_CV_MUL );
                 }
 
                 copyScenedataSubset(0, storage_id_start, storage_id_end);
@@ -231,17 +231,17 @@ struct SurgeOSC : virtual public SurgeModuleCommon {
         if( outputConnected(OUTPUT_L) && !outputConnected(OUTPUT_R) )
         {
             // Special mono mode
-            float output = (avgl + avgr) * 5.0 * getParam(OUTPUT_GAIN);
+            float output = (avgl + avgr) * 0.5 * SURGE_TO_RACK_OSC_MUL * getParam(OUTPUT_GAIN);
             setOutput(OUTPUT_L, output);
         }
         else
         {
             if( outputConnected(OUTPUT_L) )
-                setOutput(OUTPUT_L, avgl * 10 *
+                setOutput(OUTPUT_L, avgl * SURGE_TO_RACK_OSC_MUL *
                           getParam(OUTPUT_GAIN));
             
             if( outputConnected(OUTPUT_R) )
-                setOutput(OUTPUT_R, avgr * 10 *
+                setOutput(OUTPUT_R, avgr * SURGE_TO_RACK_OSC_MUL *
                           getParam(OUTPUT_GAIN));
         }
 

--- a/src/SurgeVCF.hpp
+++ b/src/SurgeVCF.hpp
@@ -131,8 +131,8 @@ struct SurgeVCF :  public SurgeModuleCommon {
         float inpG = getParam(INPUT_GAIN);
         float outG = getParam(OUTPUT_GAIN);
 
-        float inl = inpG * getInput(INPUT_L_OR_MONO) / 10.0;
-        float inr = inpG * getInput(INPUT_R) / 10.0;
+        float inl = inpG * getInput(INPUT_L_OR_MONO) * RACK_TO_SURGE_OSC_MUL;
+        float inr = inpG * getInput(INPUT_R) * RACK_TO_SURGE_OSC_MUL;
 
         if( inputConnected(INPUT_L_OR_MONO) && ! inputConnected(INPUT_R) )
         {

--- a/src/SurgeWTOSC.hpp
+++ b/src/SurgeWTOSC.hpp
@@ -335,7 +335,7 @@ struct SurgeWTOSC : virtual public SurgeModuleCommon {
             {
                 for (int i = 0; i < n_scene_params; ++i) {
                     oscstorage->p[i].set_value_f01(getParam(OSC_CTRL_PARAM_0 + i) +
-                                                   getInput(OSC_CTRL_CV_0 + i) / 10.0);
+                                                   getInput(OSC_CTRL_CV_0 + i) * RACK_TO_SURGE_CV_MUL );
                 }
 
                 copyScenedataSubset(0, storage_id_start, storage_id_end);
@@ -350,17 +350,17 @@ struct SurgeWTOSC : virtual public SurgeModuleCommon {
         if( outputConnected(OUTPUT_L) && !outputConnected(OUTPUT_R) )
         {
             // Special mono mode
-            float output = (avgl + avgr) * 5.0 * getParam(OUTPUT_GAIN);
+            float output = (avgl + avgr) * 0.5 * SURGE_TO_RACK_OSC_MUL * getParam(OUTPUT_GAIN);
             setOutput(OUTPUT_L, output);
         }
         else
         {
             if( outputConnected(OUTPUT_L) )
-                setOutput(OUTPUT_L, avgl * 10 *
+                setOutput(OUTPUT_L, avgl * SURGE_TO_RACK_OSC_MUL *
                           getParam(OUTPUT_GAIN));
             
             if( outputConnected(OUTPUT_R) )
-                setOutput(OUTPUT_R, avgr * 10 *
+                setOutput(OUTPUT_R, avgr * SURGE_TO_RACK_OSC_MUL *
                           getParam(OUTPUT_GAIN));
         }
 

--- a/src/SurgeWaveShaper.hpp
+++ b/src/SurgeWaveShaper.hpp
@@ -30,7 +30,6 @@ struct SurgeWaveShaper : virtual public SurgeModuleCommon {
     }
 
     int processPosition = 0;
-    float wsMul = 1.0;
     float inBuffer alignas(16)[4], outBuffer alignas(16)[4];
 
     void swapWS(int i) {
@@ -38,10 +37,6 @@ struct SurgeWaveShaper : virtual public SurgeModuleCommon {
             wsPtr = nullptr;
         else
             wsPtr = GetQFPtrWaveshaper(i);
-
-        wsMul = 10.0;
-        if (i == 0 || i == wst_digi)
-            wsMul = 1.0;
 
         for (int i = 0; i < 4; ++i) {
             inBuffer[i] = 0;
@@ -75,8 +70,8 @@ struct SurgeWaveShaper : virtual public SurgeModuleCommon {
                 _mm_store_ps(outBuffer, out);
                 processPosition = 0;
             }
-            inBuffer[processPosition] = getInput(SIGNAL_IN);
-            setOutput(SIGNAL_OUT, outBuffer[processPosition] * wsMul);
+            inBuffer[processPosition] = getInput(SIGNAL_IN) * RACK_TO_SURGE_OSC_MUL;
+            setOutput(SIGNAL_OUT, outBuffer[processPosition] * SURGE_TO_RACK_OSC_MUL);
             processPosition++;
         }
     }


### PR DESCRIPTION
Surge runs on +/- 1.0 for all of its oscillators and stuff
Rack runs on 10v pp which means oscillators run at +/- 5V
I had sloppily made oscillators and effects assume +/- 10v
This change fixes it by introducing proper constants so the
code is clearer at the conversion points, and testing levels
vs Fundamental/VCO in the scope.

Closes #172