### PR TITLE
Fix temposync display

### DIFF
--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -257,7 +257,9 @@ struct SurgeFX : virtual SurgeModuleCommon {
                     fxstorage->p[orderToParam[i]].get_display(txt, false, 0);
                     if( getParam(PARAM_TEMPOSYNC_0 + i) > 0.5 )
                     {
-                        snprintf( txt, 256, "%s @ %5.1lf bpm", txt, lastBPM );
+		        char ntxt[256];
+                        snprintf( ntxt, 256, "%s @ %5.1lf bpm", txt, lastBPM );
+			strcpy(txt, ntxt);
                     }
                     paramDisplayCache[i].reset(txt);
                 }

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -319,7 +319,9 @@ struct RackSurgeParamBinding {
             p->get_display(txt, false, 0);
             if( tsbpmLabel && ts_id >= 0 && m->getParam(ts_id) > 0.5 )
             {
-                snprintf(txt, 1024, "%s @ %5.1lf bpm", txt, m->lastBPM );
+  	        char ntxt[1024];
+                snprintf(ntxt, 1024, "%s @ %5.1lf bpm", txt, m->lastBPM );
+		strcpy(txt, ntxt);
             }
             valCache.reset(txt);
             paramChanged = true;


### PR DESCRIPTION
TempoSync display used the undefined snprintf(a,n,"...", a); whic
on macOS had undefined behavior of working and on linux had undefined
behavior of not working. This meant temposync times didn't display
properly on linux. Fix.

Closes #175