### PR TITLE
Path to cleaner parameters

### DIFF
--- a/src/SurgeADSR.hpp
+++ b/src/SurgeADSR.hpp
@@ -42,7 +42,6 @@ struct SurgeADSR : virtual public SurgeModuleCommon {
     rack::dsp::SchmittTrigger envGateTrigger, envRetrig;
 
     StringCache adsrStrings[4];
-    ParamCache pc;
 
     SurgeADSR() : SurgeModuleCommon() {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
@@ -58,7 +57,7 @@ struct SurgeADSR : virtual public SurgeModuleCommon {
     virtual std::string getName() override { return "ADSR"; }
 
     virtual void setupSurge() {
-        setupSurgeCommon();
+        setupSurgeCommon(NUM_PARAMS);
 
         surge_envelope.reset(new AdsrEnvelope());
         adsrstorage = &(storage->getPatch().scene[0].adsr[0]);
@@ -77,7 +76,6 @@ struct SurgeADSR : virtual public SurgeModuleCommon {
         adsrstorage->r_s.val.i = 0;
 
         setupStorageRanges(&(adsrstorage->a), &(adsrstorage->mode));
-        pc.resize(NUM_PARAMS);
 
     }
 

--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -61,8 +61,6 @@ struct SurgeFX : virtual SurgeModuleCommon {
         NUM_LIGHTS = CAN_TEMPOSYNC_0 + NUM_FX_PARAMS
     };
 
-    ParamCache pc;
-    
     StringCache paramDisplayCache[NUM_FX_PARAMS];
     StringCache labelCache[NUM_FX_PARAMS];
     StringCache groupCache[NUM_FX_PARAMS];
@@ -83,9 +81,7 @@ struct SurgeFX : virtual SurgeModuleCommon {
     virtual std::string getName() override { return SurgeFXName<effectNum>::getName(); }
 
     void setupSurge() {
-        pc.resize(NUM_PARAMS);
-        
-        setupSurgeCommon();
+        setupSurgeCommon(NUM_PARAMS);
 
         fxstorage = &(storage->getPatch().fx[0]);
         fxstorage->type.val.i = effectNum;

--- a/src/SurgeModuleCommon.cpp
+++ b/src/SurgeModuleCommon.cpp
@@ -1,0 +1,151 @@
+#include "SurgeModuleCommon.hpp"
+#include <string>
+
+void SurgeRackParamBinding::update(const ParamCache &pc, SurgeModuleCommon *m)
+{
+    bool paramChanged = false;
+    if(pc.changed(param_id,m) || (ts_id >= 0 && pc.changed(ts_id, m) ) || forceRefresh)
+    {
+        char txt[1024];
+        p->set_value_f01(m->getParam(param_id));
+        if( ts_id >= 0 )
+            p->temposync = m->getParam(ts_id) > 0.5;
+        
+        p->get_display(txt, false, 0);
+        if( tsbpmLabel && ts_id >= 0 && m->getParam(ts_id) > 0.5 )
+        {
+            char ntxt[1024];
+            snprintf(ntxt, 1024, "%s @ %5.1lf bpm", txt, m->lastBPM );
+            strcpy(txt, ntxt);
+        }
+        valCache.reset(txt);
+        paramChanged = true;
+    }
+    if(forceRefresh)
+    {
+        nameCache.reset(p->get_name());
+    }
+    
+    if( paramChanged || forceRefresh || m->inputConnected(cv_id) )
+        p->set_value_f01(m->getParam(param_id) + m->getInput(cv_id) / 10.0);
+}
+
+void SurgeModuleCommon::setupSurgeCommon(int NUM_PARAMS) 
+{
+    std::string dataPath;
+    dataPath = rack::asset::plugin(pluginInstance, "surge-data/");
+    
+    showBuildInfo();
+    storage.reset(new SurgeStorage(dataPath));
+    
+    rack::INFO("[SurgeRack] SurgeStorage::dataPath = %s", storage->datapath.c_str());
+    rack::INFO("            SurgeStorage::userDataPath = %s", storage->userDataPath.c_str());
+    rack::INFO("            SurgeStorage::wt_list.size() = %d", storage->wt_list.size());
+    
+    onSampleRateChange();
+
+    pb.resize(NUM_PARAMS);
+    pc.resize(NUM_PARAMS);
+}
+
+std::string SurgeRackParamQuantity::getLabel() {
+    SurgeModuleCommon *mc = static_cast<SurgeModuleCommon *>(module);
+    if( mc )
+    {
+        std::shared_ptr<SurgeRackParamBinding> p = mc->pb[paramId];
+        if( p.get() )
+        {
+            return p->nameCache.value;
+        }
+    }
+    rack::INFO( "GETLABEL defaulting for %s", label.c_str() );
+    return ParamQuantity::getLabel();
+}
+
+std::string SurgeRackParamQuantity::getDisplayValueString() {
+    SurgeModuleCommon *mc = static_cast<SurgeModuleCommon *>(module);
+    if( mc )
+    {
+        std::shared_ptr<SurgeRackParamBinding> pbn = mc->pb[paramId];
+        if( pbn.get() )
+        {
+            switch (pbn->p->ctrltype)
+            {
+            case ct_lforate:
+            case ct_envtime:
+            case ct_envtime_lfodecay:
+            case ct_reverbtime:
+            case ct_delaymodtime:
+                if( ! pbn->p->temposync )
+                    return pbn->valCache.value;
+                break;
+                
+            case ct_percent:
+            case ct_percent_bidirectional:
+                return pbn->valCache.value;
+                
+            default:
+                break;
+            }
+        }
+    }
+
+    return ParamQuantity::getDisplayValueString();
+}
+
+void SurgeRackParamQuantity::setDisplayValueString(std::string s) {
+    SurgeModuleCommon *mc = static_cast<SurgeModuleCommon *>(module);
+    bool foundValue = false;
+    if( mc )
+    {
+        std::shared_ptr<SurgeRackParamBinding> pbn = mc->pb[paramId];
+        if( pbn.get() )
+        {
+            float newValue = 0;
+            switch (pbn->p->ctrltype)
+            {
+            case ct_lforate:
+            case ct_envtime:
+            case ct_envtime_lfodecay:
+            case ct_reverbtime:
+            case ct_delaymodtime:
+                if( ! pbn->p->temposync )
+                {
+                    float entered = std::stof(s);
+                    // hz are 2^newValue so newValue = log2(hz)
+                    // seconds are also 2^value
+                    newValue = log2f(entered);
+                    foundValue = true;
+                }
+                break;
+            case ct_percent:
+            {
+                float entered = std::stof(s);
+                newValue = entered / 100.0;
+                foundValue = true;
+            }
+            break;
+            case ct_percent_bidirectional:
+            {
+                float entered = std::stof(s);
+                newValue = entered / 100.0;
+                foundValue = true;
+            }
+            break;
+            default:
+                break;
+            }
+            if( foundValue )
+            {
+                pbn->p->val.f = newValue;
+                pbn->p->bound_value(false);
+                setValue(pbn->p->get_value_f01());
+                return;
+            }
+
+        }
+    }
+
+    if( ! foundValue )
+        ParamQuantity::setDisplayValueString(s);
+}

--- a/src/SurgeOSC.hpp
+++ b/src/SurgeOSC.hpp
@@ -27,7 +27,6 @@ struct SurgeOSC : virtual public SurgeModuleCommon {
     enum OutputIds { OUTPUT_L, OUTPUT_R, NUM_OUTPUTS };
     enum LightIds { NUM_LIGHTS };
 
-    ParamCache pc;
     ParamValueStateSaver knobSaver;
     
     SurgeOSC() : SurgeModuleCommon() {
@@ -50,8 +49,7 @@ struct SurgeOSC : virtual public SurgeModuleCommon {
     StringCache paramNameCache[n_osc_params], paramValueCache[n_osc_params];
 
     virtual void setupSurge() {
-        pc.resize(NUM_PARAMS);
-        setupSurgeCommon();
+        setupSurgeCommon(NUM_PARAMS);
 
         oscConfigurations.push_back(std::pair<int, std::string>(ot_classic, "Classic"));
         oscConfigurations.push_back(std::pair<int, std::string>(ot_sinus, "Sine"));

--- a/src/SurgeVCF.hpp
+++ b/src/SurgeVCF.hpp
@@ -36,8 +36,6 @@ struct SurgeVCF :  public SurgeModuleCommon {
     };
     enum LightIds { NUM_LIGHTS };
 
-    ParamCache pc;
-
     SurgeVCF() : SurgeModuleCommon() {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(FILTER_TYPE, 0, 9, 0 );
@@ -54,8 +52,7 @@ struct SurgeVCF :  public SurgeModuleCommon {
     virtual std::string getName() override { return "VCF"; }
 
     virtual void setupSurge() {
-        pc.resize(NUM_PARAMS);
-        setupSurgeCommon();
+        setupSurgeCommon(NUM_PARAMS);
         resetBuffers();
     }
 

--- a/src/SurgeWTOSC.hpp
+++ b/src/SurgeWTOSC.hpp
@@ -36,8 +36,6 @@ struct SurgeWTOSC : virtual public SurgeModuleCommon {
         NUM_LIGHTS
     };
 
-    ParamCache pc;
-    
     SurgeWTOSC() : SurgeModuleCommon() {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         configParam(OUTPUT_GAIN, 0, 1, 1);
@@ -62,8 +60,7 @@ struct SurgeWTOSC : virtual public SurgeModuleCommon {
     std::vector<int> catOrderSkipEmpty;
     
     virtual void setupSurge() {
-        pc.resize(NUM_PARAMS);
-        setupSurgeCommon();
+        setupSurgeCommon(NUM_PARAMS);
 
         for( auto ci : storage->wtCategoryOrdering )
         {

--- a/src/SurgeWaveShaper.hpp
+++ b/src/SurgeWaveShaper.hpp
@@ -20,13 +20,10 @@ struct SurgeWaveShaper : virtual public SurgeModuleCommon {
 
     virtual std::string getName() override { return "WS"; }
     
-    ParamCache pc;
     StringCache dbGainCache;
 
     virtual void setupSurge() {
-        setupSurgeCommon();
-
-        pc.resize(NUM_PARAMS);
+        setupSurgeCommon(NUM_PARAMS);
     }
 
     int processPosition = 0;


### PR DESCRIPTION
This commit sets out a path to using a more consistent parmeter
binding class, and in the LFO where that conversion is complete
showing how that gives you the Rack UI features like smarter
right mouse editors and labels.

This addressed parts of #99, #100 and #147. I think I'm going to
collapse those all into #147 and use that to hang the rest of the
implementation of this in the other classes.