### PR TITLE
ParamBindings for ADSR

### DIFF
--- a/scripts/buildutil.sh
+++ b/scripts/buildutil.sh
@@ -75,7 +75,7 @@ clean()
 
 build_module()
 {
-    RACK_DIR=$RACK_INSTALL_DIR/Rack-SDK make -j 4 all
+    RACK_DIR=$RACK_INSTALL_DIR/Rack-SDK make -k -j 4 all
 }
 
 install_module()

--- a/src/SurgeADSR.cpp
+++ b/src/SurgeADSR.cpp
@@ -110,8 +110,7 @@ SurgeADSRWidget::SurgeADSRWidget(SurgeADSRWidget::M *module)
         addChild(TextDisplayLight::create(
             rack::Vec(padFromEdge * 2 + 15, ADSRYPos(i) +2),
             rack::Vec(box.size.x - padFromEdge * 3 - 20, adsrTextH),
-            module ? module->adsrStrings[i].getValue : []() { return "null"; },
-            module ? module->adsrStrings[i].getDirty : []() { return false; },
+            module ? &(module->pb[M::A_PARAM + i]->valCache ) : nullptr,
             13, NVG_ALIGN_LEFT | NVG_ALIGN_TOP, surgeWhite()));
     }
 

--- a/src/SurgeLFO.hpp
+++ b/src/SurgeLFO.hpp
@@ -108,7 +108,6 @@ struct SurgeLFO : virtual public SurgeModuleCommon {
         for( int i=RATE_PARAM; i<= R_PARAM; ++i )
         {
             p0->temposync = false;
-            rack::INFO("Setting shared ptr at %d size=%d", i, pb.size() );
             pb[i] = std::shared_ptr<SurgeRackParamBinding>(new SurgeRackParamBinding(p0, i, RATE_CV + (i-RATE_PARAM)));
             p0++;
         }

--- a/src/SurgeModuleCommon.cpp
+++ b/src/SurgeModuleCommon.cpp
@@ -1,7 +1,7 @@
 #include "SurgeModuleCommon.hpp"
 #include <string>
 
-void SurgeRackParamBinding::update(const ParamCache &pc, SurgeModuleCommon *m)
+void SurgeRackParamBinding::updateFloat(const ParamCache &pc, SurgeModuleCommon *m)
 {
     bool paramChanged = false;
     if(pc.changed(param_id,m) || (ts_id >= 0 && pc.changed(ts_id, m) ) || forceRefresh)
@@ -26,8 +26,58 @@ void SurgeRackParamBinding::update(const ParamCache &pc, SurgeModuleCommon *m)
         nameCache.reset(p->get_name());
     }
     
-    if( paramChanged || forceRefresh || m->inputConnected(cv_id) )
+    if( paramChanged || forceRefresh || (cv_id >= 0 && m->inputConnected(cv_id)) )
         p->set_value_f01(m->getParam(param_id) + m->getInput(cv_id) / 10.0);
+}
+
+void SurgeRackParamBinding::updateBool(const ParamCache &pc, SurgeModuleCommon *m, bool notIt)
+{
+    bool paramChanged = false;
+    if(pc.changed(param_id,m) || forceRefresh)
+    {
+        char txt[1024];
+
+        bool current = m->getParam(param_id) > 0.5;
+        if( notIt ) current = ! current;
+
+        if( ( current != p->val.b ) || forceRefresh )
+        {
+            p->val.b = current;
+            p->get_display(txt, false, 0);
+            valCache.reset(txt);
+            paramChanged = true;
+        }
+    }
+
+    if(forceRefresh)
+    {
+        nameCache.reset(p->get_name());
+    }
+}
+
+
+void SurgeRackParamBinding::updateInt(const ParamCache &pc, SurgeModuleCommon *m)
+{
+    bool paramChanged = false;
+    if(pc.changed(param_id,m) || forceRefresh)
+    {
+        char txt[1024];
+
+        int current = (int)m->getParam(param_id);
+
+        if( ( current != p->val.i ) || forceRefresh )
+        {
+            p->val.i = current;
+            p->get_display(txt, false, 0);
+            valCache.reset(txt);
+            paramChanged = true;
+        }
+    }
+
+    if(forceRefresh)
+    {
+        nameCache.reset(p->get_name());
+    }
 }
 
 void SurgeModuleCommon::setupSurgeCommon(int NUM_PARAMS) 

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -280,13 +280,35 @@ struct SurgeRackParamBinding {
     Parameter *p;
     int param_id, cv_id, ts_id;
 
+    typedef enum UpdateType
+    {
+        FLOAT,
+        INT,
+        BOOL,
+        BOOL_NOT
+    } UpdateType;
+
+
+    UpdateType updateType;
     StringCache valCache;
     StringCache nameCache;
 
     bool forceRefresh = false;
     bool tsbpmLabel = false;
     
-    SurgeRackParamBinding(Parameter *_p, int _param_id, int _cv_id) {
+    SurgeRackParamBinding(UpdateType t, Parameter *_p, int _param_id, int _cv_id = -1) {
+        this->updateType = t;
+        this->p = _p;
+        this->cv_id = _cv_id;
+        this->param_id = _param_id;
+        this->ts_id = -1;
+        valCache.reset( "value" );
+        nameCache.reset( "name" );
+        forceRefresh = true;
+    }
+
+    SurgeRackParamBinding(Parameter *_p, int _param_id, int _cv_id = -1) {
+        this->updateType = FLOAT;
         this->p = _p;
         this->cv_id = _cv_id;
         this->param_id = _param_id;
@@ -303,8 +325,28 @@ struct SurgeRackParamBinding {
         ts_id = i;
         tsbpmLabel = label;
     }
+
+    void update(const ParamCache &pc, SurgeModuleCommon *m) {
+        switch( updateType )
+        {
+        case FLOAT:
+            updateFloat(pc, m);
+            break;
+        case BOOL:
+            updateBool(pc, m, false);
+            break;
+        case BOOL_NOT:
+            updateBool(pc, m, true);
+            break;
+        case INT:
+            updateInt(pc, m);
+            break;
+        }
+    }
     
-    void update(const ParamCache &pc, SurgeModuleCommon *m);
+    void updateFloat(const ParamCache &pc, SurgeModuleCommon *m);
+    void updateInt(const ParamCache &pc, SurgeModuleCommon *m);
+    void updateBool(const ParamCache &pc, SurgeModuleCommon *m, bool n);
 };
 
 struct ParamValueStateSaver {


### PR DESCRIPTION
Expand the ParamBinding mechanism to handle a broader group
of types. Apply it to ADSR reducing the ADSR code by a lot.
Turn on custom parambinding aware editors for the ADSR controls.