### PR TITLE
Move FX to ParamBinding

### DIFF
--- a/src/SurgeEQ.cpp
+++ b/src/SurgeEQ.cpp
@@ -55,22 +55,6 @@ struct SurgeEQWidget : SurgeModuleWidgetCommon {
         drawTextBGRect( vg, box.size.x/4 + 2 * portX + 2 * padMargin, masterGainY + labelHeight + padMargin + ( portY-textHeight)/2,
                         box.size.x/2 - 2 * portX - 2 * padMargin, textHeight );
 
-        
-        if( module )
-        {
-            M *mc = dynamic_cast<M *>(module);
-            if( mc )
-            {
-                rack::INFO( "[SurgeRack][FX Blank %s]", mc->getName().c_str() );
-                for( int i=0; i<n_fx_params; ++i )
-                {
-                    rack::INFO( "  %d '%s'/'%s' = '%s'", i,
-                          mc->groupCache[i].getValue().c_str(),
-                          mc->labelCache[i].getValue().c_str(),
-                          mc->paramDisplayCache[i].getValue().c_str() );
-                }
-            }
-        }
     }
 };
 
@@ -119,7 +103,7 @@ SurgeEQWidget::SurgeEQWidget(SurgeEQWidget::M *module)
             yPos += portY + padMargin;
             addChild(TextDisplayLight::create(rack::Vec( i * bandRegion + padFromEdge, yPos ),
                                               rack::Vec( bandRegion - 2 * padFromEdge, textHeight ),
-                                              module ? &(module->paramDisplayCache[parImd]) : nullptr,
+                                              module ? &(module->pb[parImd]->valCache) : nullptr,
                                               12, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE, surgeWhite() ) );
 
         }
@@ -132,7 +116,7 @@ SurgeEQWidget::SurgeEQWidget(SurgeEQWidget::M *module)
     addChild(TextDisplayLight::create( rack::Vec( box.size.x/4 + 2 * portX + 3 * padMargin,
                                                   masterGainY + labelHeight + padMargin + ( portY-textHeight)/2),
                                        rack::Vec(box.size.x/2 - 2 * portX - 3 * padMargin, textHeight ),
-                                       module ? &(module->paramDisplayCache[9]) : nullptr,
+                                       module ? &(module->pb[9]->valCache) : nullptr,
                                        12, NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT, surgeWhite() ) );
 
     

--- a/src/SurgeFX.cpp
+++ b/src/SurgeFX.cpp
@@ -96,7 +96,7 @@ SurgeFXWidget<effectType>::SurgeFXWidget(SurgeFXWidget<effectType>::M *module)
         int tx = 4 * padMargin + 2 * portX + surgeSwitchX + 2;
         addChild(TextDisplayLight::create(rack::Vec(tx, yPos),
                                           rack::Vec(textAreaWidth, controlHeight - padMargin),
-                                          module ? &(module->labelCache[i]) : nullptr,
+                                          module ? &(module->pb[i]->nameCache) : nullptr,
                                           13, NVG_ALIGN_LEFT | NVG_ALIGN_BOTTOM, SurgeStyle::surgeOrange()));
 
         addChild(TextDisplayLight::create(rack::Vec(tx, yPos),
@@ -106,7 +106,7 @@ SurgeFXWidget<effectType>::SurgeFXWidget(SurgeFXWidget<effectType>::M *module)
 
         addChild(TextDisplayLight::create(rack::Vec(tx , yPos),
                                           rack::Vec(textAreaWidth - 2 * padMargin, controlHeight - padMargin),
-                                          module ? &(module->paramDisplayCache[i]) : nullptr,
+                                          module ? &(module->pb[i]->valCache) : nullptr,
                                           14, NVG_ALIGN_RIGHT | NVG_ALIGN_MIDDLE, SurgeStyle::surgeWhite()));
         
     }

--- a/src/SurgeFreqShift.cpp
+++ b/src/SurgeFreqShift.cpp
@@ -84,7 +84,7 @@ SurgeFreqShiftWidget::SurgeFreqShiftWidget(SurgeFreqShiftWidget::M *module)
         addChild(TextDisplayLight::create(
                      rack::Vec(xText + padMargin, yp + portY + 1.5 * padMargin),
                      rack::Vec(box.size.x - xText - 2 * padMargin, textHeight),
-                     module ? &(module->paramDisplayCache[i]) : nullptr,
+                     module ? &(module->pb[i]->valCache) : nullptr,
                      12,
                      NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE,
                      surgeWhite()

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -380,6 +380,8 @@ struct ParamValueStateSaver {
 
 struct SurgeRackParamQuantity : rack::engine::ParamQuantity
 {
+    int ts_companion = -2;
+    
     void setDisplayValueString(std::string s) override;
 	std::string getLabel() override;
     std::string getDisplayValueString() override;

--- a/src/SurgeRotary.cpp
+++ b/src/SurgeRotary.cpp
@@ -96,7 +96,7 @@ SurgeRotaryWidget::SurgeRotaryWidget(SurgeRotaryWidget::M *module)
         addChild(TextDisplayLight::create(
                      rack::Vec(xText + padMargin, yp + portY + 1.5 * padMargin),
                      rack::Vec(box.size.x - xText - 2 * padMargin, textHeight),
-                     module ? &(module->paramDisplayCache[i]) : nullptr,
+                     module ? &(module->pb[i]->valCache) : nullptr,
                      12,
                      NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE,
                      surgeWhite()

--- a/src/SurgeVOC.cpp
+++ b/src/SurgeVOC.cpp
@@ -136,7 +136,7 @@ SurgeVOCWidget<effectType>::SurgeVOCWidget(SurgeVOCWidget<effectType>::M *module
         int tx = 3 * padMargin + 2 * portX + 2;
         addChild(TextDisplayLight::create(rack::Vec(tx , yPos),
                                           rack::Vec(textAreaWidth - 2 * padMargin, textAreaHeight ),
-                                          module ? &(module->paramDisplayCache[i]) : nullptr,
+                                          module ? &(module->pb[pa]->valCache) : nullptr,
                                           14, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE, SurgeStyle::surgeWhite()));
         
     }


### PR DESCRIPTION
Move FX to the ParamBinding class, eliminating a load of
redundant code. Also gives us the right mouse behavior on
all FX widgets properly. Moreover, the temposync widgets
get their name correctly.

Many but not all parameter types are bidirectionally supported
from string. Keep plugging away. But this is good enough to merge
and a real improvement.