### PR TITLE
SurgeOSC is polyphonic

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -87,7 +87,7 @@
 			"slug": "SurgeOSC",
 			"name": "SurgeOSC",
 			"description": "The Surge Oscillators",
-			"tags": ["VCO"]
+			"tags": ["VCO", "Polyphonic"]
 		},
 		{
 			"slug": "SurgeWaveShaper",

--- a/src/SurgeADSR.hpp
+++ b/src/SurgeADSR.hpp
@@ -131,7 +131,7 @@ struct SurgeADSR : virtual public SurgeModuleCommon {
         {
             if( inputConnected(CLOCK_CV_INPUT) )
             {
-                updateBPMFromClockCV(getInput(CLOCK_CV_INPUT), args.sampleTime, args.sampleRate );
+                updateBPMFromClockCV(inputs[CLOCK_CV_INPUT].getVoltage(), args.sampleTime, args.sampleRate );
             }
             else
             {

--- a/src/SurgeClock.hpp
+++ b/src/SurgeClock.hpp
@@ -48,7 +48,7 @@ struct SurgeClock : virtual public SurgeModuleCommon {
             phase -= 1;
         float gate = ( phase > getParam(PULSE_WIDTH) ) ? 0 : RACK_CV_MAX_LEVEL;
 
-        setOutput(CLOCK_CV_OUT,getParam(CLOCK_CV));
-        setOutput(GATE_OUT, gate);
+        outputs[CLOCK_CV_OUT].setVoltage(getParam(CLOCK_CV));
+        outputs[GATE_OUT].setVoltage(gate);
     }
 };

--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -192,8 +192,8 @@ struct SurgeFX : virtual SurgeModuleCommon {
         if( SurgeFXTraits<effectNum>::hasModulatorSignal )
         {
             float mg = getParam(MODULATOR_GAIN);
-            float ml = mg * getInput(MODULATOR_L_OR_MONO);
-            float mr = mg * getInput(MODULATOR_R);
+            float ml = mg * inputs[MODULATOR_L_OR_MONO].getVoltageSum();
+            float mr = mg * inputs[MODULATOR_R].getVoltageSum();
             if( inputConnected(MODULATOR_L_OR_MONO) && ! inputConnected(MODULATOR_R) )
             {
                 modulatorL[bufferPos] = ml;
@@ -219,7 +219,7 @@ struct SurgeFX : virtual SurgeModuleCommon {
             
             if( inputConnected(CLOCK_CV_INPUT) )
             {
-                updateBPMFromClockCV(getInput(CLOCK_CV_INPUT), args.sampleTime, args.sampleRate );
+                updateBPMFromClockCV(inputs[CLOCK_CV_INPUT].getVoltage(), args.sampleTime, args.sampleRate );
             }
             else
             {
@@ -242,12 +242,12 @@ struct SurgeFX : virtual SurgeModuleCommon {
 
         if( outputConnected(OUTPUT_L_OR_MONO) && ! outputConnected(OUTPUT_R) )
         {
-            setOutput(OUTPUT_L_OR_MONO, 0.5 * ( outl + outr ) );
+            outputs[OUTPUT_L_OR_MONO].setVoltage( 0.5 * ( outl + outr ) );
         }
         else
         {
-            setOutput(OUTPUT_L_OR_MONO, outl );
-            setOutput(OUTPUT_R, outr );
+            outputs[OUTPUT_L_OR_MONO].setVoltage( outl );
+            outputs[OUTPUT_R].setVoltage( outr );
         }
     }
 

--- a/src/SurgeLFO.hpp
+++ b/src/SurgeLFO.hpp
@@ -139,20 +139,20 @@ struct SurgeLFO : virtual public SurgeModuleCommon {
 
         if (lastStep == 0) {
             bool inNewAttack = false;
-            if (inputConnected(GATE_IN) && envGateTrigger.process(getInput(GATE_IN))) {
+            if (inputConnected(GATE_IN) && envGateTrigger.process(inputs[GATE_IN].getVoltage())) {
                 lfostorage->trigmode.val.i = lm_keytrigger;
                 copyScenedataSubset(0, storage_id_start, storage_id_end);
                 surge_lfo->attack();
                 inNewAttack = true;
             }
 
-            if (inputConnected(RETRIG_IN) && envRetrig.process(getInput(RETRIG_IN))) {
+            if (inputConnected(RETRIG_IN) && envRetrig.process(inputs[RETRIG_IN].getVoltage())) {
                 surge_lfo->retrigger_EG = true;
             }
 
             if( inputConnected(CLOCK_CV_INPUT) )
             {
-                updateBPMFromClockCV(getInput(CLOCK_CV_INPUT), args.sampleTime, args.sampleRate );
+                updateBPMFromClockCV(inputs[CLOCK_CV_INPUT].getVoltage(), args.sampleTime, args.sampleRate );
             }
             else
             {
@@ -176,7 +176,7 @@ struct SurgeLFO : virtual public SurgeModuleCommon {
             */
 
             bool isGateConnected = inputConnected(GATE_IN);
-            bool isGated = getInput(GATE_IN) >= 1.f;
+            bool isGated = inputs[GATE_IN].getVoltage() >= 1.f;
 
             if( isGateConnected )
             {
@@ -236,6 +236,6 @@ struct SurgeLFO : virtual public SurgeModuleCommon {
         lastStep++;
         float frac = 1.0 * lastStep / BLOCK_SIZE;
         float outputI = output0 * (1.0-frac) + output1 * frac;
-        setOutput(OUTPUT_ENV, outputI * SURGE_TO_RACK_OSC_MUL);
+        outputs[OUTPUT_ENV].setVoltage(outputI * SURGE_TO_RACK_OSC_MUL);
     }
 };

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -166,14 +166,6 @@ struct SurgeModuleCommon : public rack::Module {
         this->params[id].setValue(v);
     }
 
-    inline float getInput(int id) {
-        return this->inputs[id].getVoltage();
-    }
-
-    inline void setOutput(int id, float v) {
-        this->outputs[id].setVoltage(v);
-    }
-
     inline void setLight(int id, float val) {
         this->lights[id].setBrightness(val);
     }
@@ -185,7 +177,7 @@ struct SurgeModuleCommon : public rack::Module {
     inline bool outputConnected(int id) {
         return this->outputs[id].isConnected();
     }
-
+    
     void copyScenedataSubset(int scene, int start, int end) {
         int s = storage->getPatch().scene_start[scene];
         for(int i=start; i<end; ++i )

--- a/src/SurgeVCF.hpp
+++ b/src/SurgeVCF.hpp
@@ -127,8 +127,8 @@ struct SurgeVCF :  public SurgeModuleCommon {
 
         float inpG = getParam(INPUT_GAIN);
 
-        float inl = inpG * getInput(INPUT_L_OR_MONO) * RACK_TO_SURGE_OSC_MUL;
-        float inr = inpG * getInput(INPUT_R) * RACK_TO_SURGE_OSC_MUL;
+        float inl = inpG * inputs[INPUT_L_OR_MONO].getVoltage() * RACK_TO_SURGE_OSC_MUL;
+        float inr = inpG * inputs[INPUT_R].getVoltage() * RACK_TO_SURGE_OSC_MUL;
 
         if( inputConnected(INPUT_L_OR_MONO) && ! inputConnected(INPUT_R) )
         {

--- a/src/SurgeWTOSC.hpp
+++ b/src/SurgeWTOSC.hpp
@@ -332,13 +332,13 @@ struct SurgeWTOSC : virtual public SurgeModuleCommon {
             {
                 for (int i = 0; i < n_scene_params; ++i) {
                     oscstorage->p[i].set_value_f01(getParam(OSC_CTRL_PARAM_0 + i) +
-                                                   getInput(OSC_CTRL_CV_0 + i) * RACK_TO_SURGE_CV_MUL );
+                                                   inputs[OSC_CTRL_CV_0 + i].getVoltage() * RACK_TO_SURGE_CV_MUL );
                 }
 
                 copyScenedataSubset(0, storage_id_start, storage_id_end);
                 float pitch0 = (getParam(PITCH_0_IN_FREQ) > 0.5) ? getParam(PITCH_0) : (int)getParam(PITCH_0);
                 surge_osc->process_block(
-                    pitch0 + getInput(PITCH_CV) * 12.0, 0, true);
+                    pitch0 + inputs[PITCH_CV].getVoltage() * 12.0, 0, true);
             }
         }
 
@@ -348,16 +348,16 @@ struct SurgeWTOSC : virtual public SurgeModuleCommon {
         {
             // Special mono mode
             float output = (avgl + avgr) * 0.5 * SURGE_TO_RACK_OSC_MUL * getParam(OUTPUT_GAIN);
-            setOutput(OUTPUT_L, output);
+            outputs[OUTPUT_L].setVoltage(output);
         }
         else
         {
             if( outputConnected(OUTPUT_L) )
-                setOutput(OUTPUT_L, avgl * SURGE_TO_RACK_OSC_MUL *
-                          getParam(OUTPUT_GAIN));
+                outputs[OUTPUT_L].setVoltage( avgl * SURGE_TO_RACK_OSC_MUL *
+                                              getParam(OUTPUT_GAIN));
             
             if( outputConnected(OUTPUT_R) )
-                setOutput(OUTPUT_R, avgr * SURGE_TO_RACK_OSC_MUL *
+                outputs[OUTPUT_R].setVoltage(avgr * SURGE_TO_RACK_OSC_MUL *
                           getParam(OUTPUT_GAIN));
         }
 


### PR DESCRIPTION
This change implements a polyphonic oscillator (surge-osc)
allowing all the non-wavetable oscillator shapes to be played
in up to 16 voices. It also removes the dangers-for-poly-port
API points "getInput" and "setOutput" which were vestigal
leftovers from when I wanted to try and have 0.6.2 and 1.0
work at the same time.