### PR TITLE
Performance Profiling #1

### DIFF
--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -339,6 +339,7 @@ struct SurgeRackParamBinding {
             updateInt(pc, polyChannel, m);
             break;
         }
+        forceRefresh = false;
     }
     
     void updateFloat(const ParamCache &pc, int polyChannel, SurgeModuleCommon *m);

--- a/src/SurgeWTOSC.hpp
+++ b/src/SurgeWTOSC.hpp
@@ -330,7 +330,7 @@ struct SurgeWTOSC : virtual public SurgeModuleCommon {
             pc.update(this);
             if( outputConnected(OUTPUT_L) || outputConnected(OUTPUT_R) )
             {
-                for (int i = 0; i < n_scene_params; ++i) {
+                for (int i = 0; i < n_osc_params; ++i) {
                     oscstorage->p[i].set_value_f01(getParam(OSC_CTRL_PARAM_0 + i) +
                                                    inputs[OSC_CTRL_CV_0 + i].getVoltage() * RACK_TO_SURGE_CV_MUL );
                 }


### PR DESCRIPTION
1. Stupidly the ParamBinding kept forceRefresh true always so toggle it
   once refreshed
2. Add some simd helpers to ADSR
3. Fix a CPU stealing bug in OSC and WTOSC where they iterated over way
   more parameters than needed to do updates.