### PR TITLE
SurgeModuleCommon data location

### DIFF
--- a/src/SurgeModuleCommon.cpp
+++ b/src/SurgeModuleCommon.cpp
@@ -79,7 +79,7 @@ void SurgeRackParamBinding::updateInt(const ParamCache &pc, int polyChannel, Sur
 void SurgeModuleCommon::setupSurgeCommon(int NUM_PARAMS) 
 {
     std::string dataPath;
-    dataPath = rack::asset::plugin(pluginInstance, "surge-data/");
+    dataPath = rack::asset::plugin(pluginInstance, "build/surge-data/");
     
     showBuildInfo();
     storage.reset(new SurgeStorage(dataPath));


### PR DESCRIPTION
Used to be I correctly put surge-data in dist but that all changed
sometime, but I sitll had a stale directory so i didn't know it.
User @SteveRussell33 found the error. This is the obvious fix
which is "dist has build in the name so put build in the name".

Closes #203.