### PR TITLE
Data path for different rack versions

### DIFF
--- a/src/SurgeModuleCommon.cpp
+++ b/src/SurgeModuleCommon.cpp
@@ -80,6 +80,17 @@ void SurgeModuleCommon::setupSurgeCommon(int NUM_PARAMS)
 {
     std::string dataPath;
     dataPath = rack::asset::plugin(pluginInstance, "build/surge-data/");
+    std::string cxml = dataPath + "configuration.xml";
+    FILE *cxmlF = fopen(cxml.c_str(), "r");
+    if( cxmlF )
+    {
+        fclose(cxmlF);
+    }
+    else
+    {
+        dataPath = rack::asset::plugin(pluginInstance, "surge-data/" );
+    }
+
     
     showBuildInfo();
     storage.reset(new SurgeStorage(dataPath));


### PR DESCRIPTION
Rack v1 before 95ea82c2 put distributables of form "build/foo"
into the dist as "foo"; and after as "build/foo". Since I want
this software to run with various v1.0 in the dev period, handle
either outcome when I read the files at the cost of a throwawy
fopen per module creation.

Closes #203