### PR TITLE
Move version to beta1 rather than alpha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ RACK_DIR ?= ../..
 RACK_VERSION=1
 RACK_FLAG=-DRACK_V1
 
-SURGE_RACK_BASE_VERSION=1.0-alpha
+SURGE_RACK_BASE_VERSION=1.beta1
 SURGE_RACK_PLUG_VERSION=$(shell git rev-parse --short HEAD)
 SURGE_RACK_SURGE_VERSION=$(shell cd surge && git rev-parse --short HEAD)
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
 	"slug": "SurgeRack",
 	"name": "Surge for Rack",
-	"version": "1.alpha.LOCALBUILD",
+	"version": "1.beta1.LOCALBUILD",
 	"license": "GPL-3.0-or-later",
 	"author": "The Surge Team",
 	"authorEmail": "",

--- a/scripts/make-fx-presets.py
+++ b/scripts/make-fx-presets.py
@@ -29,7 +29,7 @@ def parseType(typeel, prefix=""):
 def basedata():
     data = {}
     data["plugin"] = "SurgeRack"
-    data["version"] = "1.alpha.LOCALBUILD"
+    data["version"] = "1.beta1.LOCALBUILD"
     data["model"] = ""
     data["params"] = []
     for i in range(27):

--- a/scripts/resetversion.sh
+++ b/scripts/resetversion.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 gitrev=`git rev-parse --short HEAD`
-version="1.alpha.${gitrev}"
+version="1.beta1.${gitrev}"
 echo "Updating to version=$version"
 tf=`mktemp`
 jq --arg VERSION "$version" '.version=$VERSION' plugin.json > $tf


### PR DESCRIPTION
Versions now take the form of 1.beta1.LOCALBUILD in your dev
area and 1.beta1.(githash) in the CI pipeline from master.
I will branch this to make 1.beta1.0 for the community build.