### PR TITLE
PatchPlayer needs a storage data path

### DIFF
--- a/src/SurgePatchPlayer.hpp
+++ b/src/SurgePatchPlayer.hpp
@@ -72,7 +72,8 @@ struct SurgePatchPlayer : virtual public SurgeModuleCommon {
     
     virtual void setupSurge() {
         setupSurgeCommon(NUM_PARAMS);
-        surge_synth.reset(new SurgeSynthesizer(new HeadlessPluginLayerProxy()));
+        surge_synth.reset(new SurgeSynthesizer(new HeadlessPluginLayerProxy(), storage->datapath));
+
         storage.reset(&(surge_synth->storage));
         storage->refresh_patchlist();
         


### PR DESCRIPTION
PatchPlayer was using default storage data path. For
people with the VST installed this means it worked; for people
without the VST installed this meant it SEGVed. Fix by passing
the plugin path through the constructors.

Addresses #216