### PR TITLE
FX initial state is in config params

### DIFF
--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -64,17 +64,17 @@ struct SurgeFX : virtual SurgeModuleCommon {
     StringCache groupCache[NUM_FX_PARAMS];
 
     SurgeFX() : SurgeModuleCommon() {
+        setupSurge();
+
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
         for (int i = 0; i < 12; ++i) {
-            configParam<SurgeRackParamQuantity>(FX_PARAM_0 + i, 0, 1, 0 );
+            configParam<SurgeRackParamQuantity>(FX_PARAM_0 + i, 0, 1, pb[i]->p->get_value_f01() );
             configParam<SurgeRackParamQuantity>(PARAM_TEMPOSYNC_0 + i, 0, 1, 0 );
         }
 
         configParam(INPUT_GAIN, 0, 1, 1, "Input Gain");
         configParam(OUTPUT_GAIN, 0, 1, 1, "Output Gain");
         configParam(MODULATOR_GAIN, 0, 1, 1, "Modulator Gain" );
-        
-        setupSurge();
     }
 
     virtual std::string getName() override { return SurgeFXName<effectNum>::getName(); }
@@ -95,16 +95,6 @@ struct SurgeFX : virtual SurgeModuleCommon {
         // Do default values
         reorderSurgeParams();
 
-        if( ! firstRespawnIsFromJSON )
-        {
-            // Set up the parametres based on the thingy
-            for( int i=0; i<n_fx_params; ++i )
-            {
-                setParam(FX_PARAM_0 + i, pb[i]->p->get_value_f01() );
-            }
-        }
-        
-        
         for (auto i = 0; i < BLOCK_SIZE; ++i) {
             bufferL[i] = 0.0f;
             bufferR[i] = 0.0f;


### PR DESCRIPTION
Prior to this diff, I set up the params for FX backwards; I set
their default to zero then set their value with get_f01. This meant
that RMB/Initialize went back to a different state than drag-out-new

So fix this by initializing surge before rack; and then once that's
done read the f01 as the param defaults.

Closes #230