### PR TITLE
Fix Cross-Compilation Case Error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ endif
 
 ifdef ARCH_WIN
 SOURCES += $(SRL)/filesystem/filesystem.cpp
-LDFLAGS += -lWinmm
+LDFLAGS += -lwinmm
 endif
 
 ifdef ARCH_LIN


### PR DESCRIPTION
When compiling windows software on ubuntu (which rack does for its
builds) case matters; thanks to @cschol for this diff.

Closes #244