### PR TITLE
Fix an uninit memory in the FX

### DIFF
--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -105,6 +105,10 @@ struct SurgeFX : virtual SurgeModuleCommon {
         }
 
 
+        // You would think this is what you do yeah? But return_level is special and is
+        // uninitalized so we have to do a mild hack. This will tell the copyrange to
+        // ignore this one.
+        fxstorage->return_level.id = -1;
         setupStorageRanges((Parameter *)fxstorage, &(fxstorage->p[n_fx_params-1]));
     }
 

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -169,13 +169,17 @@ struct SurgeModuleCommon : public rack::Module {
         Parameter *oap = start;
         while( oap <= endIncluding )
         {
-            if( oap->id > max_id ) max_id = oap->id;
-            if( oap->id < min_id ) min_id = oap->id;
+            if( oap->id >= 0 )
+            {
+                if( oap->id > max_id ) max_id = oap->id;
+                if( oap->id < min_id ) min_id = oap->id;
+            }
             oap++;
         }
 
         storage_id_start = min_id;
-        storage_id_end = max_id + 1;        
+        storage_id_end = max_id + 1;
+        rack::INFO( "[SurgeRack] Storage Ranges are %d -> %d", storage_id_start, storage_id_end );
     }
     
     std::unique_ptr<SurgeStorage> storage;


### PR DESCRIPTION
The 'return-value' param was never initialized in surge. This is
actually correct, but I have to handle it in rack, where I care a bit
more. This led to a UMR and a crash

Closes #246