### PR TITLE
Clamp BPM to avoid overflows

### DIFF
--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -116,6 +116,11 @@ struct SurgeModuleCommon : public rack::Module {
         float samplesPerBeat = 1.0/dPhase;
         float secondsPerBeat = samplesPerBeat / sampleRate;
         float beatsPerMinute = 60.0 / secondsPerBeat;
+
+        // Folks can put in insane BPMs if they mis-wire their rack. Lets
+        // put in a clamp for well beyond the usable range
+        beatsPerMinute = rack::clamp(beatsPerMinute, 1.f, 1024.f);
+        
         lastBPM = beatsPerMinute;
 
         if( storage.get() )

--- a/src/SurgeStyle.hpp
+++ b/src/SurgeStyle.hpp
@@ -286,7 +286,7 @@ struct SurgeStyle {
             nvgBeginPath(vg);
             nvgSave(vg);
             nvgFontFaceId(vg, fontId(vg));
-            nvgFontSize(vg, 12);
+            nvgFontSize(vg, 10);
             nvgFillColor(vg, surgeWhite() );
             nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_CENTER );
             nvgText(vg, x + + portX / 2 + padMargin, y + padMargin, "bpm cv", NULL );
@@ -299,7 +299,7 @@ struct SurgeStyle {
             nvgBeginPath(vg);
             nvgSave(vg);
             nvgFontFaceId(vg, fontId(vg));
-            nvgFontSize(vg, 12);
+            nvgFontSize(vg, 10);
             nvgTranslate(vg, x + padMargin + portX + clockPad - 10, y );
             nvgRotate( vg, M_PI/2 );
             nvgFillColor(vg, surgeWhite() );


### PR DESCRIPTION
The CLK CV were driving BPM; so relabel them appropriately and
clamp the resulting BPM into a range of (1,1024) to avoid temposync
algos (like rotary) going unstable.

Closes #249