### PR TITLE
Rename SurgeStyle so that the names are logical

### DIFF
--- a/src/SurgeADSR.cpp
+++ b/src/SurgeADSR.cpp
@@ -43,7 +43,7 @@ struct SurgeADSRWidget : SurgeModuleWidgetCommon {
 
         int iotxt = box.size.y - ioMargin - 1.5;
         nvgBeginPath(vg);
-        nvgFillColor(vg, surgeWhite());
+        nvgFillColor(vg, ioRegionText());
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 12);
         nvgTextAlign(vg, NVG_ALIGN_BOTTOM | NVG_ALIGN_CENTER);
@@ -63,7 +63,7 @@ struct SurgeADSRWidget : SurgeModuleWidgetCommon {
             nvgFontSize(vg, 20);
             nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_CENTER);
 
-            nvgFillColor(vg, surgeBlue());
+            nvgFillColor(vg, panelLabel());
             nvgText(vg, padFromEdge  + 5, ADSRYPos(i), lab[i].c_str(), NULL);
             drawTextBGRect(vg, padFromEdge * 2 + 12, ADSRYPos(i) + 1,
                                        box.size.x - padFromEdge * 3 - 20,
@@ -78,7 +78,7 @@ struct SurgeADSRWidget : SurgeModuleWidgetCommon {
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 12);
         nvgTextAlign(vg, NVG_ALIGN_MIDDLE | NVG_ALIGN_RIGHT);
-        nvgFillColor(vg, surgeBlue());
+        nvgFillColor(vg, panelLabel());
         nvgText(vg, box.size.x - modeXOff - padMargin, modeYPos + 21 / 2.0, "Mode", NULL);
 
         nvgTextAlign(vg, NVG_ALIGN_BOTTOM | NVG_ALIGN_CENTER);
@@ -115,7 +115,7 @@ SurgeADSRWidget::SurgeADSRWidget(SurgeADSRWidget::M *module)
             rack::Vec(padFromEdge * 2 + 15, ADSRYPos(i) +2),
             rack::Vec(box.size.x - padFromEdge * 3 - 20, adsrTextH),
             module ? &(module->pb[M::A_PARAM + i]->valCache ) : nullptr,
-            13, NVG_ALIGN_LEFT | NVG_ALIGN_TOP, surgeWhite()));
+            13, NVG_ALIGN_LEFT | NVG_ALIGN_TOP, parameterValueText()));
     }
 
     for (int i = M::A_PARAM; i <= M::R_PARAM; ++i) {

--- a/src/SurgeBiquad.cpp
+++ b/src/SurgeBiquad.cpp
@@ -31,7 +31,7 @@ struct SurgeBiquadWidget : SurgeModuleWidgetCommon {
             nvgBeginPath(vg);
             nvgFontFaceId(vg, fontId(vg));
             nvgFontSize(vg, 14);
-            nvgStrokeColor(vg, surgeBlue());
+            nvgStrokeColor(vg, panelLabel());
             nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_LEFT );
             nvgText( vg, b.pos.x, b.pos.y, labels[i].c_str(), NULL );
 
@@ -95,7 +95,7 @@ SurgeBiquadWidget::SurgeBiquadWidget(SurgeBiquadWidget::M *module)
                      module ? &(module->pStrings[i] ) : nullptr,
                      12,
                      NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE,
-                     surgeWhite()));
+                     parameterValueText()));
 
 
     }

--- a/src/SurgeChorus.cpp
+++ b/src/SurgeChorus.cpp
@@ -77,7 +77,7 @@ struct SurgeChorusWidget : SurgeModuleWidgetCommon {
                 nvgBeginPath(vg);
                 nvgFontFaceId(vg, fontId(vg));
                 nvgFontSize(vg, 12);
-                nvgFillColor(vg, surgeBlue());
+                nvgFillColor(vg, panelLabel());
                 nvgTextAlign(vg, NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT );
                 nvgText(vg, cb.pos.x, cb.pos.y + cb.size.y / 2, labels[i].c_str(), NULL );
 
@@ -85,7 +85,7 @@ struct SurgeChorusWidget : SurgeModuleWidgetCommon {
                 nvgMoveTo( vg, cb.pos.x + 30, cb.pos.y + cb.size.y / 2);
                 nvgLineTo( vg, boxw - padFromEdge - upperTextWidth + 4, cb.pos.y + cb.size.y / 2 );
                 nvgStrokeWidth(vg, 1 );
-                nvgStrokeColor(vg, surgeBlue());
+                nvgStrokeColor(vg, panelLabel());
                 nvgStroke(vg);
                 
                 float rx = boxw - padFromEdge - upperTextWidth;
@@ -106,7 +106,7 @@ struct SurgeChorusWidget : SurgeModuleWidgetCommon {
                 nvgFontFaceId(vg, fontId(vg));
                 nvgFontSize(vg, 12);
                 nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_LEFT );
-                nvgFillColor(vg, surgeBlue() );
+                nvgFillColor(vg, panelLabel());
                 nvgText( vg, 0, 0, labels[i].c_str(), NULL );
                 
                 float bounds[4];
@@ -192,7 +192,7 @@ SurgeChorusWidget::SurgeChorusWidget(SurgeChorusWidget::M *module)
                      module ? &(module->pb[paramId[i]]->valCache ) : nullptr,
                      12,
                      NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE,
-                     surgeWhite()));
+                     parameterValueText()));
 
     }
 
@@ -212,7 +212,7 @@ SurgeChorusWidget::SurgeChorusWidget(SurgeChorusWidget::M *module)
                      module ? &(module->pb[paramId[i]]->valCache ) : nullptr,
                      12,
                      NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE,
-                     surgeWhite()));
+                     parameterValueText()));
 
     }
 

--- a/src/SurgeClock.cpp
+++ b/src/SurgeClock.cpp
@@ -16,7 +16,7 @@ struct SurgeClockWidget : SurgeModuleWidgetCommon {
     int topOfInput = RACK_HEIGHT - 5 * padMargin - 3 * labelHeight - 2 * portY + textHeight;
     
     void addLabel(NVGcontext *vg, int yp, const char *label,
-                  NVGcolor col = surgeBlue()) {
+                  NVGcolor col = panelLabel()) {
         nvgBeginPath(vg);
         nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
         nvgFontFaceId(vg, fontId(vg));
@@ -41,9 +41,9 @@ struct SurgeClockWidget : SurgeModuleWidgetCommon {
                                    2 * portY + 2 * labelHeight +
                                        4 * padMargin);
         yPos += padMargin;
-        addLabel(vg, yPos, "CV", surgeWhite());
+        addLabel(vg, yPos, "CV", ioRegionText());
         yPos += labelHeight + portY + padMargin;
-        addLabel(vg, yPos, "Gate", surgeWhite());
+        addLabel(vg, yPos, "Gate", ioRegionText());
     }
 };
 
@@ -75,7 +75,7 @@ SurgeClockWidget::SurgeClockWidget(SurgeClockWidget::M *module)
                  module ? &(module->bpmCache) : nullptr,
                  11,
                  NVG_ALIGN_MIDDLE | NVG_ALIGN_CENTER,
-                 surgeWhite()
+                 parameterValueText()
                  ));
 
     addParam(rack::createParam<SurgeKnobRooster>(
@@ -89,7 +89,7 @@ SurgeClockWidget::SurgeClockWidget(SurgeClockWidget::M *module)
                  module ? &(module->pwCache) : nullptr,
                  11,
                  NVG_ALIGN_MIDDLE | NVG_ALIGN_CENTER,
-                 surgeWhite()
+                 parameterValueText()
                  ));
 
 

--- a/src/SurgeEQ.cpp
+++ b/src/SurgeEQ.cpp
@@ -32,7 +32,7 @@ struct SurgeEQWidget : SurgeModuleWidgetCommon {
                 nvgBeginPath(vg);
                 nvgMoveTo(vg, bandRegion * (i+1), bandY0 + bandLOffset);
                 nvgLineTo(vg, bandRegion * (i+1), bandY0 + 3 * bandCHeight + bandLOffset - 10 );
-                nvgStrokeColor(vg, backgroundDarkGray());
+                nvgStrokeColor(vg, panelSeparator() );
                 nvgStrokeWidth(vg, 1 );
                 nvgStroke(vg);
             }
@@ -43,7 +43,7 @@ struct SurgeEQWidget : SurgeModuleWidgetCommon {
                 nvgBeginPath(vg);
                 nvgFontFaceId(vg, fontId(vg));
                 nvgFontSize(vg,12);
-                nvgStrokeColor(vg,surgeBlue());
+                nvgStrokeColor(vg, panelLabel());
                 nvgText(vg, bandRegion * ( i + 0.5 ), yPos, lab[j].c_str(), NULL );
 
                 yPos += labelHeight + padMargin + portY + padMargin;
@@ -104,7 +104,7 @@ SurgeEQWidget::SurgeEQWidget(SurgeEQWidget::M *module)
             addChild(TextDisplayLight::create(rack::Vec( i * bandRegion + padFromEdge, yPos ),
                                               rack::Vec( bandRegion - 2 * padFromEdge, textHeight ),
                                               module ? &(module->pb[parImd]->valCache) : nullptr,
-                                              12, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE, surgeWhite() ) );
+                                              12, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE, parameterValueText() ) );
 
         }
     }
@@ -117,7 +117,7 @@ SurgeEQWidget::SurgeEQWidget(SurgeEQWidget::M *module)
                                                   masterGainY + labelHeight + padMargin + ( portY-textHeight)/2),
                                        rack::Vec(box.size.x/2 - 2 * portX - 3 * padMargin, textHeight ),
                                        module ? &(module->pb[9]->valCache) : nullptr,
-                                       12, NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT, surgeWhite() ) );
+                                       12, NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT, parameterValueText() ) );
 
     
 }

--- a/src/SurgeFX.cpp
+++ b/src/SurgeFX.cpp
@@ -27,7 +27,7 @@ struct SurgeFXWidget : SurgeModuleWidgetCommon {
         drawBlueIORect(vg, box.size.x/2 - portX / 2 - padMargin, orangeLine + ioMargin,
                        portX + 2 * padMargin, box.size.y - orangeLine - 2 * ioMargin );
         nvgBeginPath(vg);
-        nvgFillColor(vg, surgeWhite() );
+        nvgFillColor(vg, ioRegionText() );
         nvgFontFaceId(vg, fontId(vg) );
         nvgFontSize(vg, 11);
         nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM );
@@ -94,17 +94,17 @@ SurgeFXWidget<effectType>::SurgeFXWidget(SurgeFXWidget<effectType>::M *module)
         addChild(TextDisplayLight::create(rack::Vec(tx, yPos),
                                           rack::Vec(textAreaWidth, controlHeight - padMargin),
                                           module ? &(module->pb[i]->nameCache) : nullptr,
-                                          13, NVG_ALIGN_LEFT | NVG_ALIGN_BOTTOM, SurgeStyle::surgeOrange()));
+                                          13, NVG_ALIGN_LEFT | NVG_ALIGN_BOTTOM, SurgeStyle::parameterNameText()));
 
         addChild(TextDisplayLight::create(rack::Vec(tx, yPos),
                                           rack::Vec(textAreaWidth, controlHeight - padMargin),
                                           module ? &(module->groupCache[i]) : nullptr,
-                                          9, NVG_ALIGN_LEFT | NVG_ALIGN_TOP, SurgeStyle::surgeWhite()));
+                                          9, NVG_ALIGN_LEFT | NVG_ALIGN_TOP, SurgeStyle::parameterValueText()));
 
         addChild(TextDisplayLight::create(rack::Vec(tx , yPos),
                                           rack::Vec(textAreaWidth - 2 * padMargin, controlHeight - padMargin),
                                           module ? &(module->pb[i]->valCache) : nullptr,
-                                          14, NVG_ALIGN_RIGHT | NVG_ALIGN_MIDDLE, SurgeStyle::surgeWhite()));
+                                          14, NVG_ALIGN_RIGHT | NVG_ALIGN_MIDDLE, SurgeStyle::parameterValueText()));
         
     }
 }

--- a/src/SurgeFreqShift.cpp
+++ b/src/SurgeFreqShift.cpp
@@ -24,7 +24,7 @@ struct SurgeFreqShiftWidget : SurgeModuleWidgetCommon {
             nvgBeginPath(vg);
             nvgFontFaceId(vg, fontId(vg));
             nvgFontSize(vg, 14);
-            nvgFillColor(vg, surgeBlue() );
+            nvgFillColor(vg, panelLabel() );
             nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE );
             nvgText( vg, padFromEdge, y0 + portY / 2, lab[i].c_str(), NULL );
 
@@ -87,7 +87,7 @@ SurgeFreqShiftWidget::SurgeFreqShiftWidget(SurgeFreqShiftWidget::M *module)
                      module ? &(module->pb[i]->valCache) : nullptr,
                      12,
                      NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE,
-                     surgeWhite()
+                     parameterValueText()
                      ));
 
 

--- a/src/SurgeLFO.cpp
+++ b/src/SurgeLFO.cpp
@@ -73,7 +73,7 @@ struct SurgeLFOWidget : SurgeModuleWidgetCommon {
             nvgBeginPath(vg);
             nvgFontFaceId(vg,fontId(vg));
             nvgFontSize(vg, 12);
-            nvgFillColor(vg, surgeWhite());
+            nvgFillColor(vg, ioRegionText());
             nvgTextAlign(vg,NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
             nvgText(vg, xc, yc, lab[i].c_str(), NULL );
         }
@@ -81,7 +81,7 @@ struct SurgeLFOWidget : SurgeModuleWidgetCommon {
         nvgBeginPath( vg );
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 11);
-        nvgFillColor(vg, surgeBlue() );
+        nvgFillColor(vg, panelLabel() );
         nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
         nvgText( vg, UIW - SCREW_WIDTH * 1.2, SCREW_WIDTH + padMargin, "uni", NULL );
         nvgText( vg, UIW - SCREW_WIDTH * 1.2, SCREW_WIDTH + padMargin + 11, "bi", NULL );
@@ -111,14 +111,6 @@ struct SurgeLFOWidget : SurgeModuleWidgetCommon {
             rack::Vec p = envPoint(i);
             rack::Vec s = envSize(i);
 
-            // Obviously kill this when we are done
-            //nvgBeginPath(vg);
-            //nvgRect(vg, p.x, p.y, s.x, s.y );
-            //nvgFillColor(vg, nvgRGB( 255, i * 40, 255 ) );
-            //nvgFill(vg);
-            //nvgStrokeColor( vg, nvgRGB( 0, 0, 0 ) );
-            //nvgStroke(vg);
-
             // OK so rotated text
             nvgBeginPath(vg);
             nvgSave(vg);
@@ -127,7 +119,7 @@ struct SurgeLFOWidget : SurgeModuleWidgetCommon {
             nvgFontFaceId(vg, fontId(vg));
             nvgFontSize(vg, 13);
             nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_LEFT );
-            nvgFillColor(vg, surgeBlue() );
+            nvgFillColor(vg, panelLabel() );
             nvgText( vg, 0, 0, envlabel[i].c_str(), NULL );
 
             float bounds[4];
@@ -213,7 +205,7 @@ SurgeLFOWidget::SurgeLFOWidget(SurgeLFOWidget::M *module)
     addChild(TextDisplayLight::create(rack::Vec( box.size.x / 2 + 2 * padMargin, rateTop ),
                                       rack::Vec( box.size.x / 2 - 3 * padMargin, portY-2 ),
                                       module ? &(module->pb[0]->valCache) : nullptr,
-                                      14, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE, surgeWhite() ) );
+                                      14, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE, parameterValueText() ) );
     
     
     std::vector<float> mpd = { 3, 2, 4 };
@@ -232,7 +224,7 @@ SurgeLFOWidget::SurgeLFOWidget(SurgeLFOWidget::M *module)
         addChild(TextDisplayLight::create(rack::Vec(xpos, ypos - 2 + portY + 2*padMargin ),
                                           rack::Vec(box.size.x/3 - 2 * padFromEdge, 14 ),
                                           module ? &(module->pb[mpd[i]]->valCache) : nullptr,
-                                          12, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE, surgeWhite()));
+                                          12, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE, parameterValueText()));
     }
 
     addChild(rack::createLight<rack::SmallLight<rack::BlueLight>>(rack::Vec(box.size.x/2 + 25, envPos),
@@ -264,7 +256,7 @@ SurgeLFOWidget::SurgeLFOWidget(SurgeLFOWidget::M *module)
         addChild(TextDisplayLight::create(rack::Vec(xstart + padMargin, ep.y + portY + padMargin  ),
                                           rack::Vec(textAreaWidth - 2 * padMargin, controlHeight - padMargin),
                                           module ? &(module->pb[idx]->valCache) : nullptr,
-                                          14, NVG_ALIGN_LEFT | NVG_ALIGN_TOP, surgeWhite()));
+                                          14, NVG_ALIGN_LEFT | NVG_ALIGN_TOP, parameterValueText()));
     }
 }
 

--- a/src/SurgeNoise.cpp
+++ b/src/SurgeNoise.cpp
@@ -15,7 +15,7 @@ struct SurgeNoiseWidget : SurgeModuleWidgetCommon {
     int topOfInput = orangeLine + padMargin;
     
     void addLabel(NVGcontext *vg, int yp, const char *label,
-                  NVGcolor col = surgeBlue()) {
+                  NVGcolor col = panelLabel()) {
         nvgBeginPath(vg);
         nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
         nvgFontFaceId(vg, fontId(vg));
@@ -47,7 +47,7 @@ struct SurgeNoiseWidget : SurgeModuleWidgetCommon {
         nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 12);
-        nvgFillColor(vg, surgeWhite());
+        nvgFillColor(vg, ioRegionText());
         nvgText(vg, box.size.x / 2, box.size.y - ioMargin - 1.5, "Noise", NULL);
 
 

--- a/src/SurgeOSC.cpp
+++ b/src/SurgeOSC.cpp
@@ -28,7 +28,7 @@ struct SurgeOSCWidget : public virtual SurgeModuleWidgetCommon {
             vg, x0 + ioMargin, orangeLine + ioMargin,
             ioRegionWidth, box.size.y - orangeLine - 2 * ioMargin);
 
-        nvgFillColor(vg, surgeWhite());
+        nvgFillColor(vg, ioRegionText());
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 12);
         nvgSave(vg);
@@ -64,7 +64,7 @@ struct SurgeOSCWidget : public virtual SurgeModuleWidgetCommon {
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 15);
         nvgTextAlign(vg, NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT );
-        nvgFillColor(vg, surgeBlue() );
+        nvgFillColor(vg, panelLabel() );
         nvgText(vg, padFromEdge, pitchLY, "Pitch", NULL );
 
         float xt = pitchCtrlX + surgeRoosterX + portX + 2 * padMargin + 12;
@@ -73,14 +73,14 @@ struct SurgeOSCWidget : public virtual SurgeModuleWidgetCommon {
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 10);
         nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_LEFT );
-        nvgFillColor(vg, surgeBlue() );
+        nvgFillColor(vg, panelLabel() );
         nvgText(vg, xt, pitchY + 2, "f", NULL );
 
         nvgBeginPath(vg);
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 10);
         nvgTextAlign(vg, NVG_ALIGN_BOTTOM | NVG_ALIGN_LEFT );
-        nvgFillColor(vg, surgeBlue() );
+        nvgFillColor(vg, panelLabel() );
         nvgText(vg, xt, pitchY + surgeRoosterY - 4, "n", NULL );
 
         
@@ -159,7 +159,7 @@ SurgeOSCWidget::SurgeOSCWidget(SurgeOSCWidget::M *module)
                  module ? &(module->pitch0DisplayCache) : nullptr,
                  14,
                  NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE,
-                 surgeWhite()
+                 parameterValueText()
                  ));
 
     for (int i = 0; i < n_osc_params; ++i) {
@@ -180,7 +180,7 @@ SurgeOSCWidget::SurgeOSCWidget(SurgeOSCWidget::M *module)
         addChild(TextDisplayLight::create(
                      rack::Vec(xt+2, yp+1 ), rack::Vec(box.size.x - xt - padMargin, controlHeightPer - padMargin - 2),
                      module ? (&module->paramValueCache[i]) : nullptr,
-                     15, NVG_ALIGN_LEFT | NVG_ALIGN_BOTTOM, surgeWhite()));
+                     15, NVG_ALIGN_LEFT | NVG_ALIGN_BOTTOM, parameterValueText()));
     }
 }
 

--- a/src/SurgePatchPlayer.cpp
+++ b/src/SurgePatchPlayer.cpp
@@ -61,7 +61,7 @@ struct SurgePatchPlayerWidget : public virtual SurgeModuleWidgetCommon {
         drawBlueIORect(vg, box.size.x/2 - portX / 2 - padMargin, orangeLine + ioMargin,
                        portX + 2 * padMargin, box.size.y - orangeLine - 2 * ioMargin );
         nvgBeginPath(vg);
-        nvgFillColor(vg, surgeWhite() );
+        nvgFillColor(vg, ioRegionText() );
         nvgFontFaceId(vg, fontId(vg) );
         nvgFontSize(vg, 11);
         nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM );
@@ -87,7 +87,7 @@ struct SurgePatchPlayerWidget : public virtual SurgeModuleWidgetCommon {
             nvgFontFaceId(vg, fontId(vg));
             nvgFontSize(vg, 12);
             nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_CENTER );
-            nvgFillColor( vg, surgeBlue());
+            nvgFillColor( vg, panelLabel());
             nvgText( vg, xc + w/2, yc, lb.c_str(), NULL );
 
         }
@@ -140,19 +140,19 @@ SurgePatchPlayerWidget::SurgePatchPlayerWidget(SurgePatchPlayerWidget::M *module
                  rack::Vec(padMargin, SCREW_WIDTH + padMargin ),
                  rack::Vec(box.size.x - 2 * padMargin, 15 ),
                  module ? &(module->patchInfoCache[0]) : nullptr,
-                 13, NVG_ALIGN_TOP| NVG_ALIGN_CENTER, surgeWhite() ));
+                 13, NVG_ALIGN_TOP| NVG_ALIGN_CENTER, parameterValueText() ));
 
     addChild(TextDisplayLight::create(
                  rack::Vec(padMargin, SCREW_WIDTH + padMargin  + 13 ),
                  rack::Vec(box.size.x - 2 * padMargin, 25 ),
                  module ? &(module->patchInfoCache[1]) : nullptr,
-                 20, NVG_ALIGN_TOP| NVG_ALIGN_CENTER, surgeWhite() ));
+                 20, NVG_ALIGN_TOP| NVG_ALIGN_CENTER, parameterValueText() ));
 
     addChild(TextDisplayLight::create(
                  rack::Vec(padMargin, SCREW_WIDTH + padMargin  + 13 + 2 + 20 ),
                  rack::Vec(box.size.x - 2 * padMargin, 15 ),
                  module ? &(module->patchInfoCache[2]) : nullptr,
-                 11, NVG_ALIGN_TOP| NVG_ALIGN_CENTER, surgeWhite() ));
+                 11, NVG_ALIGN_TOP| NVG_ALIGN_CENTER, parameterValueText() ));
 
     
     auto xpf = [this](int i) { return this->colOneEnd + this->catitlodsz * ( i + 0.5 ) - this->surgeRoosterX / 2.0; };
@@ -182,7 +182,7 @@ SurgePatchPlayerWidget::SurgePatchPlayerWidget(SurgePatchPlayerWidget::M *module
                  rack::Vec(xTPos + 4, yTPos),
                  rack::Vec(box.size.x - xTPos - 2 * padMargin, 19 ),
                  module ? &(module->patchCategoryName) : nullptr,
-                 15, NVG_ALIGN_MIDDLE | NVG_ALIGN_CENTER, surgeWhite()));
+                 15, NVG_ALIGN_MIDDLE | NVG_ALIGN_CENTER, parameterValueText()));
 
     for( int i=0; i<3; ++i )
     {
@@ -220,6 +220,7 @@ SurgePatchPlayerWidget::SurgePatchPlayerWidget(SurgePatchPlayerWidget::M *module
         else if( i == 4 ) yTPos += 16 + padMargin;
         else yTPos += 14 + padMargin;
 
+        // FIXME - we need a method for this too
         float fs = 15 - ( i - 3 ) * ( i - 3 ) / 3.0;
         float colR = 255 - ( i - 3 ) * ( i - 3 ) * 10 - (i!=3?70:0);
         float colG = 255 - ( i - 3 ) * ( i - 3 ) * 10 - (i!=3?70:0);

--- a/src/SurgeRotary.cpp
+++ b/src/SurgeRotary.cpp
@@ -40,7 +40,7 @@ struct SurgeRotaryWidget : SurgeModuleWidgetCommon {
             nvgBeginPath(vg);
             nvgFontFaceId(vg, fontId(vg));
             nvgFontSize(vg, 14);
-            nvgFillColor(vg, surgeBlue() );
+            nvgFillColor(vg, panelLabel() );
             nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE );
             nvgText( vg, padFromEdge, labelY, lab[i].c_str(), NULL );
 
@@ -120,7 +120,7 @@ SurgeRotaryWidget::SurgeRotaryWidget(SurgeRotaryWidget::M *module)
                      module ? &(module->pb[i]->valCache) : nullptr,
                      12,
                      NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE,
-                     surgeWhite()
+                     parameterValueText()
                      ));
 
 

--- a/src/SurgeStyle.cpp
+++ b/src/SurgeStyle.cpp
@@ -31,20 +31,21 @@ void SurgeStyle::drawBlueIORect(NVGcontext *vg, float x0, float y0, float w,
     nvgBeginPath(vg);
     NVGpaint vGradient;
     vGradient =
-        nvgLinearGradient(vg, x0, y0, x0, y0 + h, SurgeStyle::surgeBlueBright(),
-                          SurgeStyle::surgeBlue());
+        nvgLinearGradient(vg, x0, y0, x0, y0 + h,
+                          ioRegionBackgroundGradientStart(),
+                          ioRegionBackgroundGradientEnd());
 
     nvgRoundedRect(vg, x0, y0, w, h, 5);
     nvgFillPaint(vg, vGradient);
     nvgFill(vg);
     nvgBeginPath(vg);
     nvgRoundedRect(vg, x0, y0 + 1, w, h - 1, 5);
-    nvgStrokeColor(vg, SurgeStyle::surgeBlueVeryBright());
+    nvgStrokeColor(vg, ioRegionBorderHighlight() );
     nvgStrokeWidth(vg, 1);
     nvgStroke(vg);
     nvgBeginPath(vg);
     nvgRoundedRect(vg, x0, y0, w, h, 5);
-    nvgStrokeColor(vg, SurgeStyle::surgeBlueDark());
+    nvgStrokeColor(vg, ioRegionBorder() );
     nvgStrokeWidth(vg, 1);
     nvgStroke(vg);
     nvgBeginPath(vg);
@@ -55,20 +56,20 @@ void SurgeStyle::drawTextBGRect(NVGcontext *vg, float x0, float y0, float w,
     nvgBeginPath(vg);
     nvgRoundedRect(vg, x0, y0, w, h, 5);
     NVGpaint gradient =
-        nvgLinearGradient(vg, x0, y0, x0, y0 + h, SurgeStyle::textBGBright(),
-                          SurgeStyle::textBG());
+        nvgLinearGradient(vg, x0, y0, x0, y0 + h, SurgeStyle::textBGGradientStart(),
+                          SurgeStyle::textBGGradientEnd());
     nvgFillPaint(vg, gradient);
     nvgFill(vg);
 
     nvgBeginPath(vg);
     nvgRoundedRect(vg, x0, y0, w, h - 1, 5);
-    nvgStrokeColor(vg, SurgeStyle::textBGVeryBright());
+    nvgStrokeColor(vg, SurgeStyle::textBGBorderHighlight());
     nvgStrokeWidth(vg, 1);
     nvgStroke(vg);
 
     nvgBeginPath(vg);
     nvgRoundedRect(vg, x0, y0, w, h, 5);
-    nvgStrokeColor(vg, SurgeStyle::surgeOrange());
+    nvgStrokeColor(vg, SurgeStyle::textBGBorder());
     nvgStrokeWidth(vg, 1);
     nvgStroke(vg);
 }
@@ -77,7 +78,7 @@ void SurgeStyle::drawPanelBackground(NVGcontext *vg, float w, float h,
                                      std::string displayName, bool narrowMode) {
     nvgBeginPath(vg);
     nvgRect(vg, 0, 0, w, h);
-    nvgFillColor(vg, SurgeStyle::backgroundGray());
+    nvgFillColor(vg, SurgeStyle::panelBackground() );
     nvgFill(vg);
 
     nvgBeginPath(vg);
@@ -85,13 +86,13 @@ void SurgeStyle::drawPanelBackground(NVGcontext *vg, float w, float h,
     nvgLineTo(vg, 0, 0 );
     nvgLineTo(vg, w, 0 );
     nvgLineTo(vg, w, h);
-    nvgStrokeColor(vg, SurgeStyle::backgroundDarkGray());
+    nvgStrokeColor(vg, SurgeStyle::panelBackgroundOutline());
     nvgStrokeWidth(vg, 1);
     nvgStroke(vg);
 
     nvgBeginPath(vg);
     nvgRect(vg, 0, orangeLine, w, h - orangeLine);
-    nvgFillColor(vg, SurgeStyle::surgeOrange());
+    nvgFillColor(vg, SurgeStyle::panelFooter() );
     nvgFill(vg);
 
     nvgBeginPath(vg);
@@ -99,14 +100,14 @@ void SurgeStyle::drawPanelBackground(NVGcontext *vg, float w, float h,
     nvgLineTo(vg, w, h);
     nvgLineTo(vg, 0, h );
     nvgLineTo(vg, 0, orangeLine );
-    nvgStrokeColor(vg, SurgeStyle::surgeOrangeMedium() );
+    nvgStrokeColor(vg, SurgeStyle::panelFooterOutline() );
     nvgStrokeWidth(vg, 1);
     nvgStroke(vg);
 
     nvgBeginPath(vg);
     nvgMoveTo(vg, 0, orangeLine);
     nvgLineTo(vg, w, orangeLine);
-    nvgStrokeColor(vg, SurgeStyle::surgeBlue());
+    nvgStrokeColor(vg, SurgeStyle::panelFooterSeparator() );
     nvgStrokeWidth(vg, 1);
     nvgStroke(vg);
 
@@ -127,6 +128,7 @@ void SurgeStyle::drawPanelBackground(NVGcontext *vg, float w, float h,
         nvgSave(vg);
         nvgTranslate(vg, x0, 2);
         nvgScale(vg, scaleFactor, scaleFactor);
+        // FIXME - we want to replace the color in this logo with the panelTitle color
         rack::svgDraw(vg, logoSvg->handle);
         nvgRestore(vg);
     }
@@ -137,7 +139,7 @@ void SurgeStyle::drawPanelBackground(NVGcontext *vg, float w, float h,
         nvgTextAlign(vg, NVG_ALIGN_RIGHT | NVG_ALIGN_TOP);
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 14);
-        nvgFillColor(vg, SurgeStyle::surgeBlue());
+        nvgFillColor(vg, SurgeStyle::panelTitle() );
         nvgText(vg, logoX0 - logoWidth / 2 - 3, 0, "Surge", NULL);
     }
     
@@ -145,6 +147,6 @@ void SurgeStyle::drawPanelBackground(NVGcontext *vg, float w, float h,
     nvgTextAlign(vg, (narrowMode ? NVG_ALIGN_RIGHT | NVG_ALIGN_TOP : NVG_ALIGN_LEFT | NVG_ALIGN_TOP ) );
     nvgFontFaceId(vg, fontId(vg));
     nvgFontSize(vg, 14);
-    nvgFillColor(vg, SurgeStyle::surgeBlue());
+    nvgFillColor(vg, SurgeStyle::panelTitle() );
     nvgText(vg, (narrowMode ? w - 2 : logoX0 + logoWidth / 2 + 3 ), 0, displayName.c_str(), NULL);
 }

--- a/src/SurgeStyle.hpp
+++ b/src/SurgeStyle.hpp
@@ -23,62 +23,83 @@ struct InternalFontMgr {
 };
 
 struct SurgeStyle {
-    static NVGcolor surgeBlue() { return nvgRGBA(18, 52, 99, 255); }
-    static NVGcolor surgeBlueBright() {
+    static NVGcolor x_surgeBlue() { return nvgRGBA(18, 52, 99, 255); }
+    static NVGcolor x_surgeBlueBright() {
         return nvgRGBA(18 * 1.5, 52 * 1.5, 99 * 1.8, 255);
     }
-    static NVGcolor surgeBlueVeryBright() {
+    static NVGcolor x_surgeBlueVeryBright() {
         return nvgRGBA(18 * 1.8, 52 * 1.8, 99 * 2.1, 255);
     }
-    static NVGcolor surgeBlueDark() {
+    static NVGcolor x_surgeBlueDark() {
         return nvgRGBA(18 * 0.6, 52 * 0.6, 99 * 0.8, 255);
     }
 
-    static NVGcolor surgeWhite() { return nvgRGBA(255, 255, 255, 255); }
-    static NVGcolor surgeOrange() { return nvgRGBA(255, 144, 0, 255); }
-    static NVGcolor surgeOrangeMedium() { return nvgRGBA(227, 112, 8, 255); }
-    static NVGcolor surgeOrangeDark() { return nvgRGBA(101, 50, 3, 255); }
+    static NVGcolor x_surgeWhite() { return nvgRGBA(255, 255, 255, 255); }
+    static NVGcolor x_surgeOrange() { return nvgRGBA(255, 144, 0, 255); }
+    static NVGcolor x_surgeOrangeMedium() { return nvgRGBA(227, 112, 8, 255); }
+    static NVGcolor x_surgeOrangeDark() { return nvgRGBA(101, 50, 3, 255); }
 
-    static NVGcolor textBG() { return nvgRGBA(27, 28, 32, 255); }
-    static NVGcolor textBGBright() { return nvgRGBA(60, 60, 72, 255); }
-    static NVGcolor textBGVeryBright() { return nvgRGBA(90, 90, 112, 255); }
-
-    static NVGcolor backgroundDarkGray() { return nvgRGBA(175, 176, 182, 255); }
-    static NVGcolor backgroundGray() { return nvgRGBA(205, 206, 212, 255); }
-    static NVGcolor backgroundGrayTrans() { return nvgRGBA(205, 206, 212, 0); }
-    static NVGcolor backgroundLightGray() {
+    static NVGcolor x_backgroundDarkGray() { return nvgRGBA(175, 176, 182, 255); }
+    static NVGcolor x_backgroundGray() { return nvgRGBA(205, 206, 212, 255); }
+    static NVGcolor x_backgroundGrayTrans() { return nvgRGBA(205, 206, 212, 0); }
+    static NVGcolor x_backgroundLightGray() {
         return nvgRGBA(215, 216, 222, 255);
     }
-    static NVGcolor backgroundLightOrange() {
+    static NVGcolor x_backgroundLightOrange() {
         return nvgRGBA(239, 210, 172, 255);
     }
 
-    static NVGcolor buttonBoxPressedStroke() {
-        return nvgRGB(0xf0, 0x8f, 0x35);
-    }
-    static NVGcolor buttonBoxPressedFill() {
-        return nvgRGB(0xf1, 0xb8, 0x7d);
-    }
-    static NVGcolor buttonBoxPressedText() {
-        return nvgRGB(0x1a, 0x34, 0x60);
-    }
+    /*
+    ** These are the logical colors we need
+    */
+    static NVGcolor panelBackground() { return x_backgroundGray(); }
+    static NVGcolor panelBackgroundOutline() { return x_backgroundDarkGray(); }
+    static NVGcolor panelFooter() { return x_surgeOrange(); }
+    static NVGcolor panelFooterOutline() { return x_surgeOrangeMedium(); }
+    static NVGcolor panelFooterSeparator() { return x_surgeBlue(); }
+    static NVGcolor panelLabel() { return x_surgeBlue(); }
+    static NVGcolor panelLabelRule() { return x_surgeBlue(); }
+    static NVGcolor panelTitle() { return x_surgeBlue(); }
+    static NVGcolor panelSeparator() { return x_backgroundDarkGray(); }
+    
+    static NVGcolor ioRegionText() { return x_surgeWhite(); }
+    static NVGcolor ioRegionBackgroundGradientStart() { return x_surgeBlueBright(); }
+    static NVGcolor ioRegionBackgroundGradientEnd() { return x_surgeBlue(); }
+    static NVGcolor ioRegionBorderHighlight() { return x_surgeBlueVeryBright(); }
+    static NVGcolor ioRegionBorder() { return x_surgeBlueDark(); }
+    
+    static NVGcolor parameterValueText() { return x_surgeWhite(); }
+    static NVGcolor parameterNameText() { return x_surgeOrange(); }
 
-    static NVGcolor buttonBoxOpenStroke() {
-        return nvgRGB(0xbd, 0xbb, 0xac);
-    }
-    static NVGcolor buttonBoxOpenFill() {
-        return nvgRGB(0xf0, 0xee, 0xdc);
-    }
-    static NVGcolor buttonBoxOpenText() {
-        return nvgRGB(0xc8, 0x7b, 0x2c);
-    }
+    static NVGcolor textBGGradientStart() { return nvgRGBA(60, 60, 72, 255); }
+    static NVGcolor textBGGradientEnd() { return nvgRGBA(27, 28, 32, 255); }
+    static NVGcolor textBGBorderHighlight() { return nvgRGBA(90, 90, 112, 255); }
+    static NVGcolor textBGBorder() { return x_surgeOrange(); }
 
-    static NVGcolor buttonBoxContainerStroke() {
-        return nvgRGB(0xc8, 0x7b, 0x2c);
-    }
-    static NVGcolor buttonBoxContainerFill() {
-        return nvgRGB(0x37, 0x36, 0x32);
-    }
+
+    static NVGcolor buttonBankSelectedGradientTop() { return nvgRGB( 0xFF, 0x9A, 0x10 ); }
+    static NVGcolor buttonBankSelectedGradientMid() { return nvgRGB( 0xF0, 0xAD, 0x53 ); }
+    static NVGcolor buttonBankSelectedGradientEnd() { return nvgRGB( 0xFF, 0x9A, 0x10 ); }
+    static NVGcolor buttonBankSelectedOutline() { return nvgRGBA( 0xFF, 0x21, 0x00, 90 ); }
+
+    static NVGcolor buttonBankSelectedLightGradientTop() { return nvgRGB( 0x2f, 0x87, 0xFF ); }
+    static NVGcolor buttonBankSelectedLightGradientEnd() { return nvgRGB( 0x30, 0x88, 0xFF ); }
+    static NVGcolor buttonBankSelectedLightOutline() { return nvgRGB( 0, 0, 0 ); }
+
+    static NVGcolor buttonBankSelectedLabelGlow() { return nvgRGB( 0xFF, 0xFF, 0xFF ); }
+    static NVGcolor buttonBankSelectedLabel() { return nvgRGB( 0x00, 0x00, 0x00 ); }
+
+    static NVGcolor buttonBankUnselectedGradientTop() { return nvgRGB( 0xF2, 0xA6, 0x3E ); }
+    static NVGcolor buttonBankUnselectedGradientMid() { return nvgRGB( 0xFF, 0x99, 0x0D ); }
+    static NVGcolor buttonBankUnselectedGradientEnd() { return nvgRGB( 0xFF, 0x9E, 0x1A ); }
+    static NVGcolor buttonBankUnselectedOutline() { return nvgRGB( 0xFD, 0x94, 0x05 ); }
+
+    static NVGcolor buttonBankUnselectedLightFill() { return nvgRGB( 0x5C, 0x36, 0x03 ); }
+    static NVGcolor buttonBankUnselectedLightOutline() { return nvgRGB( 0, 0, 0 ); }
+
+    static NVGcolor buttonBankUnselectedLabel() { return nvgRGB( 0x00, 0x00, 0x00 ); }
+
+    static NVGcolor buttonBankDropShadow(){ return nvgRGB( 0x5C, 0x36, 0x03 ); }
 
     static const char *fontFace() {
         return "res/EncodeSansSemiCondensed-Medium.ttf";
@@ -186,7 +207,7 @@ struct SurgeStyle {
                 box.size.y - orangeLine - 2 * ioMargin,
                 (i == 0) ? 0 : 1);
 
-            nvgFillColor(vg, surgeWhite());
+            nvgFillColor(vg, ioRegionText());
             nvgFontFaceId(vg, fontId(vg));
             nvgFontSize(vg, 12);
             if (i == 0) {
@@ -243,7 +264,7 @@ struct SurgeStyle {
                 boxHt,
                 (i == 0) ? 0 : 1);
 
-            nvgFillColor(vg, surgeWhite());
+            nvgFillColor(vg, ioRegionText());
             nvgFontFaceId(vg, fontId(vg));
             nvgFontSize(vg, 12);
             nvgSave(vg);
@@ -287,7 +308,7 @@ struct SurgeStyle {
             nvgSave(vg);
             nvgFontFaceId(vg, fontId(vg));
             nvgFontSize(vg, 10);
-            nvgFillColor(vg, surgeWhite() );
+            nvgFillColor(vg, ioRegionText() );
             nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_CENTER );
             nvgText(vg, x + + portX / 2 + padMargin, y + padMargin, "bpm cv", NULL );
             nvgRestore(vg);
@@ -302,7 +323,7 @@ struct SurgeStyle {
             nvgFontSize(vg, 10);
             nvgTranslate(vg, x + padMargin + portX + clockPad - 10, y );
             nvgRotate( vg, M_PI/2 );
-            nvgFillColor(vg, surgeWhite() );
+            nvgFillColor(vg, ioRegionText() );
             nvgTextAlign(vg, NVG_ALIGN_BOTTOM | NVG_ALIGN_LEFT );
             nvgText(vg, padMargin, 0, "bpm cv", NULL );
             nvgRestore(vg);
@@ -316,7 +337,7 @@ struct SurgeStyle {
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 14);
         nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_LEFT );
-        nvgFillColor( vg, surgeBlue());
+        nvgFillColor( vg, panelLabel());
         nvgText( vg, padFromEdge, y, label, NULL );
 
         float bounds[4];
@@ -330,7 +351,7 @@ struct SurgeStyle {
         nvgBeginPath(vg);
         nvgMoveTo(vg, xp, yp );
         nvgLineTo(vg, box.size.x - padFromEdge, yp );
-        nvgStrokeColor( vg, surgeBlue() );
+        nvgStrokeColor( vg, panelLabelRule() );
         nvgStrokeWidth( vg, 1 );
         nvgStroke( vg );
         return y + h;
@@ -341,7 +362,7 @@ struct SurgeStyle {
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, size);
         nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_CENTER );
-        nvgFillColor( vg, surgeBlue());
+        nvgFillColor( vg, panelLabel());
         nvgText( vg, x0 + w/2, y0, label, NULL );
 
         float bounds[4];
@@ -354,14 +375,14 @@ struct SurgeStyle {
         nvgBeginPath(vg);
         nvgMoveTo(vg, x0, yp);
         nvgLineTo(vg, bounds[0] - padMargin, yp);
-        nvgStrokeColor( vg, surgeBlue() );
+        nvgStrokeColor( vg, panelLabelRule() );
         nvgStrokeWidth( vg, 1 );
         nvgStroke(vg);
 
         nvgBeginPath(vg);
         nvgMoveTo(vg, bounds[2] + padMargin, yp);
         nvgLineTo(vg, x0 + w, yp);
-        nvgStrokeColor( vg, surgeBlue() );
+        nvgStrokeColor( vg, panelLabelRule() );
         nvgStrokeWidth( vg, 1 );
         nvgStroke(vg);
 
@@ -371,7 +392,7 @@ struct SurgeStyle {
         nvgBeginPath(vg);
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, fs);
-        nvgFillColor(vg, surgeBlue() );
+        nvgFillColor(vg, panelLabel() );
         nvgTextAlign(vg, al );
         nvgText( vg, x, y, label, NULL );
     }
@@ -383,7 +404,7 @@ struct SurgeStyle {
         nvgLineTo(vg, x0, y1-radius);
         nvgArcTo(vg, x0, y1, x0+radius, y1, radius);
         nvgLineTo(vg, x1, y1);
-        nvgStrokeColor(vg, surgeBlue());
+        nvgStrokeColor(vg, panelLabelRule());
         nvgStrokeWidth(vg, 1);
         nvgStroke(vg);
     }

--- a/src/SurgeVOC.cpp
+++ b/src/SurgeVOC.cpp
@@ -39,7 +39,7 @@ struct SurgeVOCWidget : SurgeModuleWidgetCommon {
         drawBlueIORect(vg, box.size.x/2-ioRegionWidth/2, modY0,
                        ioRegionWidth, boxHt );
 
-        nvgFillColor(vg, surgeWhite());
+        nvgFillColor(vg, ioRegionText());
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 12);
         nvgSave(vg);
@@ -138,7 +138,8 @@ SurgeVOCWidget<effectType>::SurgeVOCWidget(SurgeVOCWidget<effectType>::M *module
         addChild(TextDisplayLight::create(rack::Vec(tx , yPos),
                                           rack::Vec(textAreaWidth - 2 * padMargin, textAreaHeight ),
                                           module ? &(module->pb[pa]->valCache) : nullptr,
-                                          14, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE, SurgeStyle::surgeWhite()));
+                                          14, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE, parameterValueText()
+                     ));
         
     }
 }

--- a/src/SurgeWTOSC.cpp
+++ b/src/SurgeWTOSC.cpp
@@ -33,7 +33,7 @@ struct SurgeWTOSCWidget : public virtual SurgeModuleWidgetCommon {
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 15);
         nvgTextAlign(vg, NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT );
-        nvgFillColor(vg, surgeBlue() );
+        nvgFillColor(vg, panelLabel() );
         nvgText(vg, padFromEdge + 10, pitchY + surgeRoosterY / 2, "Pitch", NULL );
 
         float bounds[4];
@@ -52,14 +52,14 @@ struct SurgeWTOSCWidget : public virtual SurgeModuleWidgetCommon {
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 10);
         nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_LEFT );
-        nvgFillColor(vg, surgeBlue() );
+        nvgFillColor(vg, panelLabel() );
         nvgText(vg, xt, pitchY + 2, "f", NULL );
 
         nvgBeginPath(vg);
         nvgFontFaceId(vg, fontId(vg));
         nvgFontSize(vg, 10);
         nvgTextAlign(vg, NVG_ALIGN_BOTTOM | NVG_ALIGN_LEFT );
-        nvgFillColor(vg, surgeBlue() );
+        nvgFillColor(vg, panelLabel() );
         nvgText(vg, xt, pitchY + surgeRoosterY - 4, "n", NULL );
 
         xt += 7 + padMargin;
@@ -82,7 +82,7 @@ struct SurgeWTOSCWidget : public virtual SurgeModuleWidgetCommon {
             nvgBeginPath(vg);
             nvgFontFaceId(vg,fontId(vg));
             nvgFontSize(vg,12);
-            nvgFillColor(vg, surgeBlue());
+            nvgFillColor(vg, panelLabel());
             nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_CENTER );
             nvgText(vg, xpf(i), wtSelY - 14, cil[i].c_str(), NULL );
         }
@@ -148,7 +148,7 @@ SurgeWTOSCWidget::SurgeWTOSCWidget(SurgeWTOSCWidget::M *module)
                  module ? &(module->pitch0DisplayCache) : nullptr,
                  14,
                  NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE,
-                 surgeWhite()
+                 parameterValueText()
                  ));
 
     for (int i = 0; i < n_osc_params; ++i) {
@@ -169,7 +169,7 @@ SurgeWTOSCWidget::SurgeWTOSCWidget(SurgeWTOSCWidget::M *module)
         addChild(TextDisplayLight::create(
                      rack::Vec(xt+2, yp+1 ), rack::Vec(colOneEnd - xt - padMargin, controlHeightPer - padMargin - 2),
                      module ? (&module->paramValueCache[i]) : nullptr,
-                     15, NVG_ALIGN_LEFT | NVG_ALIGN_BOTTOM, surgeWhite()));
+                     15, NVG_ALIGN_LEFT | NVG_ALIGN_BOTTOM, parameterValueText()));
     }
 
     float c2w = (box.size.x - colOneEnd) / 2 + colOneEnd;
@@ -191,7 +191,7 @@ SurgeWTOSCWidget::SurgeWTOSCWidget(SurgeWTOSCWidget::M *module)
                      rack::Vec(xp, yp),
                      rack::Vec(box.size.x - colOneEnd - 2 * padMargin, 15 ),
                      module ? &(module->wtInfoCache[i]) : nullptr,
-                     13, NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT, surgeWhite() ));
+                     13, NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT, parameterValueText() ));
 
         
     }
@@ -225,7 +225,7 @@ SurgeWTOSCWidget::SurgeWTOSCWidget(SurgeWTOSCWidget::M *module)
                  rack::Vec(xTPos + 4, yTPos),
                  rack::Vec(box.size.x - xTPos - 2 * padMargin, 19 ),
                  module ? &(module->wtCategoryName) : nullptr,
-                 15, NVG_ALIGN_MIDDLE | NVG_ALIGN_CENTER, surgeWhite()));
+                 15, NVG_ALIGN_MIDDLE | NVG_ALIGN_CENTER, parameterValueText()));
 
     for( int i=0; i<7; ++i )
     {
@@ -233,6 +233,7 @@ SurgeWTOSCWidget::SurgeWTOSCWidget(SurgeWTOSCWidget::M *module)
         else if( i == 4 ) yTPos += 16 + padMargin;
         else yTPos += 14 + padMargin;
 
+        // FIXME - get this color parameterized
         float fs = 15 - ( i - 3 ) * ( i - 3 ) / 3.0;
         float colR = 255 - ( i - 3 ) * ( i - 3 ) * 10 - (i!=3?70:0);
         float colG = 255 - ( i - 3 ) * ( i - 3 ) * 10 - (i!=3?70:0);

--- a/src/SurgeWaveShaper.cpp
+++ b/src/SurgeWaveShaper.cpp
@@ -15,7 +15,7 @@ struct SurgeWaveShaperWidget : SurgeModuleWidgetCommon {
     int topOfInput = RACK_HEIGHT - 5 * padMargin - 3 * labelHeight - 2 * portY;
     
     void addLabel(NVGcontext *vg, int yp, const char *label,
-                  NVGcolor col = surgeBlue()) {
+                  NVGcolor col = panelLabel()) {
         nvgBeginPath(vg);
         nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
         nvgFontFaceId(vg, fontId(vg));
@@ -41,9 +41,9 @@ struct SurgeWaveShaperWidget : SurgeModuleWidgetCommon {
                                    2 * portY + 2 * labelHeight +
                                        4 * padMargin);
         yPos += padMargin;
-        addLabel(vg, yPos, "Input", surgeWhite());
+        addLabel(vg, yPos, "Input", ioRegionText());
         yPos += labelHeight + portY + padMargin;
-        addLabel(vg, yPos, "Output", surgeWhite());
+        addLabel(vg, yPos, "Output", ioRegionText());
     }
 };
 
@@ -98,7 +98,7 @@ SurgeWaveShaperWidget::SurgeWaveShaperWidget(SurgeWaveShaperWidget::M *module)
                : []() { return std::string("null"); },
         module ? module->dbGainCache.getDirty : []() { return false; }, 10,
         NVG_ALIGN_MIDDLE | NVG_ALIGN_CENTER,
-        surgeWhite()
+        parameterValueText()
                  ));
 
     yPos += textArea + padMargin;

--- a/src/SurgeWidgets.cpp
+++ b/src/SurgeWidgets.cpp
@@ -19,16 +19,16 @@ void stackToInfo()
 
 void SurgeButtonBank::drawSelectedButton(NVGcontext *vg, float x, float y, float w, float h, std::string label)
 {
-    NVGcolor gradientTop = nvgRGB( 0xFF, 0x9A, 0x10 );
-    NVGcolor gradientMid = nvgRGB( 0xF0, 0xAD, 0x53 );
-    NVGcolor gradientBot = nvgRGB( 0xFF, 0x9A, 0x10 );
+    NVGcolor gradientTop = SurgeStyle::buttonBankSelectedGradientTop();
+    NVGcolor gradientMid = SurgeStyle::buttonBankSelectedGradientMid();
+    NVGcolor gradientBot = SurgeStyle::buttonBankSelectedGradientEnd();
 
-    NVGcolor stroke = nvgRGBA( 0xFF, 0x21, 0x00, 255 * 0.35 );
-    NVGcolor lightStroke = nvgRGB( 0, 0, 0 );
-    NVGcolor lightFillTop = nvgRGB( 0x2F, 0x87, 0xFF );
-    NVGcolor lightFillBot = nvgRGB( 0x30, 0x88, 0xFF );
+    NVGcolor stroke = SurgeStyle::buttonBankSelectedOutline();
+    NVGcolor lightStroke = SurgeStyle::buttonBankSelectedLightOutline();
+    NVGcolor lightFillTop = SurgeStyle::buttonBankSelectedLightGradientTop();
+    NVGcolor lightFillBot = SurgeStyle::buttonBankSelectedLightGradientEnd();
 
-    NVGcolor dropShadow = nvgRGB( 0x5C, 0x36, 0x03 );
+    NVGcolor dropShadow = SurgeStyle::buttonBankDropShadow();
 
     int lightWidth = 10;
     int lightHeight = 4;
@@ -37,7 +37,7 @@ void SurgeButtonBank::drawSelectedButton(NVGcontext *vg, float x, float y, float
     // Start with the drop shadow
     nvgBeginPath(vg);
     nvgRoundedRect(vg,x+1.8,y+2.2,w-2,h-2, 3);
-    NVGpaint bgr = nvgBoxGradient(vg, x+1.8, y+1.8, w-2, h-2, 3, 3, dropShadow, SurgeStyle::backgroundGray() );
+    NVGpaint bgr = nvgBoxGradient(vg, x+1.8, y+1.8, w-2, h-2, 3, 3, dropShadow, SurgeStyle::panelBackground() );
     nvgFillPaint(vg, bgr );
     nvgFill(vg);
     
@@ -77,7 +77,7 @@ void SurgeButtonBank::drawSelectedButton(NVGcontext *vg, float x, float y, float
     nvgStroke(vg);
     
     nvgBeginPath(vg);
-    nvgFillColor(vg, nvgRGB( 255, 255, 255 ) );
+    nvgFillColor(vg, SurgeStyle::buttonBankSelectedLabelGlow() );
     nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_CENTER );
     nvgFontFaceId(vg, fontId );
     nvgFontBlur(vg, 3 );
@@ -85,7 +85,7 @@ void SurgeButtonBank::drawSelectedButton(NVGcontext *vg, float x, float y, float
     nvgText(vg, x + w/2, y + 2, label.c_str(), NULL );
 
     nvgBeginPath(vg);
-    nvgFillColor(vg, nvgRGB( 255, 255, 255 ) );
+    nvgFillColor(vg, SurgeStyle::buttonBankSelectedLabelGlow() );
     nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_CENTER );
     nvgFontFaceId(vg, fontId );
     nvgFontSize(vg, 11 );
@@ -93,7 +93,7 @@ void SurgeButtonBank::drawSelectedButton(NVGcontext *vg, float x, float y, float
     nvgText(vg, x + w/2, y + 2, label.c_str(), NULL );
 
     nvgBeginPath(vg);
-    nvgFillColor(vg, nvgRGB( 0, 0, 0 ) );
+    nvgFillColor(vg, SurgeStyle::buttonBankSelectedLabel() );
     nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_CENTER );
     nvgFontFaceId(vg, fontId );
     nvgFontSize(vg, 11 );
@@ -104,14 +104,16 @@ void SurgeButtonBank::drawSelectedButton(NVGcontext *vg, float x, float y, float
 
 void SurgeButtonBank::drawUnselectedButton(NVGcontext *vg, float x, float y, float w, float h, std::string label)
 {
-    NVGcolor gradientTop = nvgRGB( 0xF2, 0xA6, 0x3E );
-    NVGcolor gradientMid = nvgRGB( 0xFF, 0x99, 0x0D );
-    NVGcolor gradientBot = nvgRGB( 0xFF, 0x9E, 0x1A );
+    NVGcolor gradientTop = SurgeStyle::buttonBankUnselectedGradientTop();
+    NVGcolor gradientMid = SurgeStyle::buttonBankUnselectedGradientMid();
+    NVGcolor gradientBot = SurgeStyle::buttonBankUnselectedGradientEnd();
 
-    NVGcolor stroke = nvgRGB( 0xFd, 0x94, 0x05 );
-    NVGcolor lightStroke = nvgRGB( 0, 0, 0 );
-    NVGcolor lightFill = nvgRGB( 0x5C, 0x36, 0x03 );
-    NVGcolor dropShadow = nvgRGB( 0x5C, 0x36, 0x03 );
+    NVGcolor stroke = SurgeStyle::buttonBankUnselectedOutline();
+
+    NVGcolor lightStroke = SurgeStyle::buttonBankUnselectedLightOutline();
+    NVGcolor lightFill = SurgeStyle::buttonBankUnselectedLightFill();
+
+    NVGcolor dropShadow = SurgeStyle::buttonBankDropShadow();
 
     int lightWidth = 10;
     int lightHeight = 4;
@@ -120,7 +122,7 @@ void SurgeButtonBank::drawUnselectedButton(NVGcontext *vg, float x, float y, flo
     // Start with the drop shadow
     nvgBeginPath(vg);
     nvgRoundedRect(vg,x+2,y+3,w-2,h-2, 3);
-    NVGpaint bgr = nvgBoxGradient(vg, x+2, y+3, w-2, h-2, 3, 3, dropShadow, SurgeStyle::backgroundGray() );
+    NVGpaint bgr = nvgBoxGradient(vg, x+2, y+3, w-2, h-2, 3, 3, dropShadow, SurgeStyle::panelBackground() );
     nvgFillPaint(vg, bgr );
     nvgFill(vg);
     
@@ -159,7 +161,7 @@ void SurgeButtonBank::drawUnselectedButton(NVGcontext *vg, float x, float y, flo
     nvgStroke(vg);
     
     nvgBeginPath(vg);
-    nvgFillColor(vg, nvgRGB( 0, 0, 0 ) );
+    nvgFillColor(vg, SurgeStyle::buttonBankUnselectedLabel() );
     nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_CENTER );
     nvgFontFaceId(vg, fontId );
     nvgFontSize(vg, 11 );

--- a/src/SurgeWidgets.hpp
+++ b/src/SurgeWidgets.hpp
@@ -94,7 +94,7 @@ struct TextDisplayLight : public rack::widget::Widget
     create(rack::Vec pos, rack::Vec size, stringGetter_t gf,
            stringDirtyGetter_t dgf, int fsize = 15,
            int align = NVG_ALIGN_LEFT | NVG_ALIGN_TOP,
-           NVGcolor color = nvgRGBA(255, 144, 0, 255)) {
+           NVGcolor color = SurgeStyle::parameterNameText()) {
         TextDisplayLight *res = rack::createWidget<TextDisplayLight>(pos);
         res->getfn = gf;
         res->dirtyfn = dgf;
@@ -114,7 +114,7 @@ struct TextDisplayLight : public rack::widget::Widget
            const StringCache *sc,
            int fsize = 15,
            int align = NVG_ALIGN_LEFT | NVG_ALIGN_TOP,
-           NVGcolor color = nvgRGBA(255, 144, 0, 255)) {
+           NVGcolor color = SurgeStyle::parameterNameText() ) {
         if( sc )
             return TextDisplayLight::create(pos, size, sc->getValue, sc->getDirty,
                                             fsize, align, color);


### PR DESCRIPTION
As part of #251 first step is to have SurgeStyle color
names be logical (panelBackgroundOutline) vs physical (darkGray).
This makes that change and a few other color parameterizations.