### PR TITLE
Handle OSC break with 1.6.3

### DIFF
--- a/src/SurgeFX.hpp
+++ b/src/SurgeFX.hpp
@@ -109,7 +109,7 @@ struct SurgeFX : virtual SurgeModuleCommon {
         // uninitalized so we have to do a mild hack. This will tell the copyrange to
         // ignore this one.
         fxstorage->return_level.id = -1;
-        setupStorageRanges((Parameter *)fxstorage, &(fxstorage->p[n_fx_params-1]));
+        setupStorageRanges(&(fxstorage->type), &(fxstorage->p[n_fx_params-1]));
     }
 
     void reorderSurgeParams() {

--- a/src/SurgeOSC.hpp
+++ b/src/SurgeOSC.hpp
@@ -76,9 +76,10 @@ struct SurgeOSC : virtual public SurgeModuleCommon {
         ** I am making a somewhat dangerous assumption here which is a good one
         ** as long as noone changes the memory layout in SurgeStorage.h. Namely that
         ** in oscstorage all the parameters are "up front" and are in order with 
-        ** nothing between them.
+        ** nothing between them. With 1.6.3 I broke that assumptino and just assumeh tye
+        ** are contiguous
         */
-        setupStorageRanges((Parameter *)oscstorage, &(oscstorage->retrigger));
+        setupStorageRanges(&(oscstorage->type), &(oscstorage->retrigger));
 
         pc.update(this);
     }

--- a/src/SurgeWTOSC.hpp
+++ b/src/SurgeWTOSC.hpp
@@ -133,9 +133,9 @@ struct SurgeWTOSC : virtual public SurgeModuleCommon {
         ** I am making a somewhat dangerous assumption here which is a good one
         ** as long as noone changes the memory layout in SurgeStorage.h. Namely that
         ** in oscstorage all the parameters are "up front" and are in order with 
-        ** nothing between them.
+        ** nothing between them. With 1.6.3 that broke hence the expliit start point
         */
-        setupStorageRanges((Parameter *)oscstorage, &(oscstorage->retrigger));
+        setupStorageRanges(&(oscstorage->type), &(oscstorage->retrigger));
         
         pc.update(this);
     }


### PR DESCRIPTION
With 1.6.3 oscstorage becomes a class so I need to be a bit
more careful with setupStorageRanges for everything to work

Closes #254