### PR TITLE
NAN check in BiQuad

### DIFF
--- a/src/SurgeBiquad.hpp
+++ b/src/SurgeBiquad.hpp
@@ -4,6 +4,7 @@
 #include "dsp/BiquadFilter.h"
 #include "rack.hpp"
 #include <cstring>
+#include <cmath>
 
 struct SurgeBiquad :  public SurgeModuleCommon {
     enum ParamIds {
@@ -217,6 +218,9 @@ struct SurgeBiquad :  public SurgeModuleCommon {
             
             float outl, outr;
             biquad[i]->process_sample( inl, inr, outl, outr );
+
+            outl = std::isfinite(outl)? outl : 0;
+            outr = std::isfinite(outr)? outr : 0;
             
             if( ! outputConnected(OUTPUT_R) )
             {


### PR DESCRIPTION
The BiQuad filter in some cases could go unstable and NaN out
as reported in #250. This puts the VCV-Rack voltage guidelines
suggested check in place.

Closes #250