### PR TITLE
Further cleanup to Rack API shift

### DIFF
--- a/src/Surge.cpp
+++ b/src/Surge.cpp
@@ -1,7 +1,7 @@
 #include "Surge.hpp"
 #include "SurgeStorage.h"
 
-using namespace rack;
+namespace logger = rack::logger;
 
 rack::Model **fxModels = nullptr;
 int addFX(rack::Model *m, int type)

--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -17,7 +17,9 @@
 #endif
 
 namespace fs = std::experimental::filesystem;
-using namespace rack;
+
+namespace logger = rack::logger;
+using rack::appGet;
 
 #include <map>
 #include <vector>
@@ -43,7 +45,7 @@ struct ParamCache {
             cache[i] = /* float min */ -1328142.0;
     }
 
-    void update(Module *m) {
+    void update(rack::Module *m) {
         for (auto i = 0; i < np; ++i) {
             cache[i] = m->params[i].getValue();
         }
@@ -51,9 +53,9 @@ struct ParamCache {
 
     float get(int i) const { return cache[i]; }
 
-    bool changed(int i, Module *m) const { return cache[i] != m->params[i].getValue(); }
-    bool changedInt(int i, Module *m) const { return (int)cache[i] != (int)m->params[i].getValue(); }
-    bool changedAndIsNonZero(int i, Module *m) const {
+    bool changed(int i, rack::Module *m) const { return cache[i] != m->params[i].getValue(); }
+    bool changedInt(int i, rack::Module *m) const { return (int)cache[i] != (int)m->params[i].getValue(); }
+    bool changedAndIsNonZero(int i, rack::Module *m) const {
         auto r = m->params[i].getValue();
         return cache[i] != r && r > 0.5;
     }
@@ -62,8 +64,8 @@ struct ParamCache {
 
 
 
-struct SurgeModuleCommon : public Module {
-    SurgeModuleCommon() : Module() {  }
+struct SurgeModuleCommon : public rack::Module {
+    SurgeModuleCommon() : rack::Module() {  }
 
     std::string getBuildInfo() {
         char version[1024];
@@ -119,8 +121,8 @@ struct SurgeModuleCommon : public Module {
         float beatsPerMinute = 60.0 / secondsPerBeat;
 
         // Folks can put in insane BPMs if they mis-wire their rack. Lets
-        // put in a clamp for well beyond the usable range
-        beatsPerMinute = clamp(beatsPerMinute, 1.f, 1024.f);
+        // put in a rack::clamp for well beyond the usable range
+        beatsPerMinute = rack::clamp(beatsPerMinute, 1.f, 1024.f);
         
         lastBPM = beatsPerMinute;
 
@@ -355,7 +357,7 @@ struct ParamValueStateSaver {
 };
 
 
-struct SurgeRackParamQuantity : engine::ParamQuantity
+struct SurgeRackParamQuantity : rack::engine::ParamQuantity
 {
     int ts_companion = -2;
     

--- a/src/SurgeRackGUI.cpp
+++ b/src/SurgeRackGUI.cpp
@@ -33,7 +33,7 @@ struct SkinsSubmenuItem : rack::ui::MenuItem
 };
 
 void SurgeModuleWidgetCommon::appendContextMenu(rack::ui::Menu* menu ) {
-    menu->addChild(new MenuEntry);
+    menu->addChild(new rack::ui::MenuEntry);
 
     SkinsSubmenuItem *skins = new SkinsSubmenuItem;
     skins->text = "Skins";

--- a/src/SurgeStyle.cpp
+++ b/src/SurgeStyle.cpp
@@ -11,7 +11,8 @@
 
 namespace fs = std::experimental::filesystem;
 
-using namespace rack;
+namespace logger = rack::logger;
+using rack::appGet;
 
 int SurgeStyle::fid = -1;
 int SurgeStyle::fidcond = -1;
@@ -27,7 +28,7 @@ static svg_t surgeLogoWhite = nullptr;
 static svg_t getSurgeLogo() {
     if (surgeLogoWhite == nullptr) {
         surgeLogoWhite = APP->window->loadSvg(
-            asset::plugin(pluginInstance, "res/SurgeLogoOnlyWhite.svg"));
+            rack::asset::plugin(pluginInstance, "res/SurgeLogoOnlyWhite.svg"));
     }
     return surgeLogoWhite;
 }
@@ -197,7 +198,7 @@ void SurgeStyle::loadStyle(std::string styleXml)
             json_t *defj = json_object_get(fd, "defaultSkin" );
             if( defj )
                 styleXml = json_string_value( defj );
-            rack::INFO( "styleXML is now %s", styleXml.c_str() );
+            INFO( "styleXML is now %s", styleXml.c_str() );
             json_decref(fd);
         }
         
@@ -225,7 +226,7 @@ void SurgeStyle::loadStyle(std::string styleXml)
     TiXmlElement *skin = TINYXML_SAFE_TO_ELEMENT(doc.FirstChild("surge-rack-skin"));
     if( skin == nullptr )
     {
-        rack::WARN( "Unable to find surge-rack-skin in file '%s'", currentStyle.c_str());
+        WARN( "Unable to find surge-rack-skin in file '%s'", currentStyle.c_str());
         return;
     }
 
@@ -253,7 +254,7 @@ void SurgeStyle::loadStyle(std::string styleXml)
     TiXmlElement *asxml = TINYXML_SAFE_TO_ELEMENT(skin->FirstChild("assets"));
     if( asxml )
     {
-        rack::INFO( "Found Assets" );
+        INFO( "Found Assets" );
         assets.clear();
         for( auto child = asxml->FirstChild(); child; child = child->NextSibling())
         {
@@ -265,7 +266,7 @@ void SurgeStyle::loadStyle(std::string styleXml)
                 if( name && path )
                 {
                     assets[name] = path;
-                    rack::INFO( "NAME/PATH is %s %s", name, path );
+                    INFO( "NAME/PATH is %s %s", name, path );
                                         
                 }
             }

--- a/src/SurgeStyle.hpp
+++ b/src/SurgeStyle.hpp
@@ -10,6 +10,8 @@
 #include <unordered_set>
 #include <unordered_map>
 
+namespace logger = rack::logger;
+
 // Font dictionary
 struct InternalFontMgr {
     static std::map<std::string, int> fontMap;
@@ -422,7 +424,7 @@ struct SurgeStyle {
         auto it = colorMap.find(nm);
         if( it == colorMap.end() )
         {
-            rack::WARN( "Lookup failed for color '%s'", nm.c_str() );
+            WARN( "Lookup failed for color '%s'", nm.c_str() );
             return nvgRGB( 255, 0, 0 );
         }
         return it->second;
@@ -433,7 +435,7 @@ struct SurgeStyle {
         auto it = assets.find(nm);
         if( it == assets.end() )
         {
-            rack::WARN( "Lookup failed for asset '%s'", nm.c_str() );
+            WARN( "Lookup failed for asset '%s'", nm.c_str() );
             return "";
         }
         return it->second;

--- a/src/SurgeWidgets.cpp
+++ b/src/SurgeWidgets.cpp
@@ -11,7 +11,7 @@ void stackToInfo()
     int i, frames = backtrace(callstack, 128);
     char** strs = backtrace_symbols(callstack, frames);
     for (i = 0; i < frames; ++i) {
-        rack::INFO( "[SurgeRack] StackTrace[%3d]: %s", i, strs[i] );
+        INFO( "[SurgeRack] StackTrace[%3d]: %s", i, strs[i] );
     }
     free(strs);
 #endif

--- a/src/SurgeWidgets.hpp
+++ b/src/SurgeWidgets.hpp
@@ -8,7 +8,9 @@
 #include <execinfo.h>
 #endif
 
-using namespace rack;
+namespace logger = rack::logger;
+using rack::logger::log;
+using rack::appGet;
 
 void stackToInfo();
 
@@ -180,17 +182,17 @@ struct SurgeSmallKnob : rack::RoundKnob, SurgeStyle::StyleListener {
     SurgeSmallKnob() {
         SurgeStyle::addStyleListener(this);
         setSvg(APP->window->loadSvg(
-                   asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobBG"))));
+                   rack::asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobBG"))));
         overlay = new rack::widget::SvgWidget;
         fb->addChild(overlay);
         overlay->setSvg(APP->window->loadSvg(
-                            asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobOverlay"))));
+                            rack::asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobOverlay"))));
         twfg = new rack::widget::TransformWidget;
         twfg->box.size = sw->box.size;
         fb->addChild(twfg);
         fg = new rack::widget::SvgWidget;
         fg->setSvg(APP->window->loadSvg(
-                       asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobFG"))));
+                       rack::asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobFG"))));
         twfg->addChild(fg);
     }
     ~SurgeSmallKnob() {
@@ -198,11 +200,11 @@ struct SurgeSmallKnob : rack::RoundKnob, SurgeStyle::StyleListener {
     }
     void styleHasChanged() override {
         setSvg(APP->window->loadSvg(
-                   asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobBG"))));
+                   rack::asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobBG"))));
         overlay->setSvg(APP->window->loadSvg(
-                            asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobOverlay"))));
+                            rack::asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobOverlay"))));
         fg->setSvg(APP->window->loadSvg(
-                       asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobFG"))));
+                       rack::asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobFG"))));
     }
     rack::widget::SvgWidget *overlay;
     rack::widget::TransformWidget* twfg;
@@ -228,7 +230,7 @@ struct SurgeKnobRooster : rack::RoundKnob, SurgeStyle::StyleListener {
         fb->addChildBottom(shadow);
 
         underlay->setSvg(APP->window->loadSvg(
-                            asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobRoosterBG"))));
+                            rack::asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobRoosterBG"))));
 
         shadow->box.size = rack::Vec(24, 24);
         shadow->box.pos = rack::Vec(5, 9.5);
@@ -240,7 +242,7 @@ struct SurgeKnobRooster : rack::RoundKnob, SurgeStyle::StyleListener {
         setSvg(APP->window->loadSvg(rack::asset::plugin(
                                         pluginInstance, SurgeStyle::getAssetPath("surgeKnobRoosterFG"))));
         underlay->setSvg(APP->window->loadSvg(
-                            asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobRoosterBG"))));
+                            rack::asset::plugin(pluginInstance, SurgeStyle::getAssetPath("surgeKnobRoosterBG"))));
 
         shadow->box.size = rack::Vec(24, 24);
         shadow->box.pos = rack::Vec(5, 9.5);

--- a/src/UserInteractionsRack.cpp
+++ b/src/UserInteractionsRack.cpp
@@ -2,7 +2,8 @@
 #include "rack.hpp"
 #include <sstream>
 
-using namespace rack;
+namespace logger = rack::logger;
+using rack::logger::log;
 
 namespace Surge {
 namespace UserInteractions {


### PR DESCRIPTION
the rack macro INFO went from "logger::log" to "rack::logger::log"
which is a breaking change if you aren't using namespace rack, which
I'm not. And there's no release planned for that change but the source
buidls have it and the SDKs don't. So this fix works through that again
since I keep breaking my code.

Closes #273