### PR TITLE
Handle null storage with sample rate change

### DIFF
--- a/src/SurgeModuleCommon.hpp
+++ b/src/SurgeModuleCommon.hpp
@@ -65,7 +65,9 @@ struct ParamCache {
 
 
 struct SurgeModuleCommon : public rack::Module {
-    SurgeModuleCommon() : rack::Module() {  }
+    SurgeModuleCommon() : rack::Module() {
+        storage.reset(nullptr);
+    }
 
     std::string getBuildInfo() {
         char version[1024];
@@ -100,7 +102,8 @@ struct SurgeModuleCommon : public rack::Module {
         dsamplerate_inv = 1.0 / sr;
         dsamplerate_os = dsamplerate * OSC_OVERSAMPLING;
         dsamplerate_os_inv = 1.0 / dsamplerate_os;
-        storage->init_tables();
+        if( storage )
+            storage->init_tables();
     }
 
     void setupSurgeCommon(int NUM_PARAMS);


### PR DESCRIPTION
onSampleRateChange assumed storage was setup. For all modules except
clock and noise it was. This meant that loading clock and noise and
swapping sample rate was a hard crash on mac and a wierd crash on
windows. Addresses #281.