### PR TITLE
Remove the blanking of CFLAGS in our makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ DEPS += $(libsurge)
 $(libsurge):
 	# Out-of-source build dir
 	echo $(CMAKE)
-	cd surge && CFLAGS= && $(CMAKE) -Bignore/rack-build -G "Unix Makefiles" -DSURGE_SKIP_JUCE_FOR_RACK=TRUE -DSURGE_SKIP_LUA=TRUE
+	cd surge && $(CMAKE) -Bignore/rack-build -G "Unix Makefiles" -DSURGE_SKIP_JUCE_FOR_RACK=TRUE -DSURGE_SKIP_LUA=TRUE
 	# $(CMAKE) doesn't work here since the arguments are borked so use make directly. Sigh.
-	cd surge/ignore/rack-build && CFLAGS= && make -j 4 surge-common
+	cd surge/ignore/rack-build && make -j 4 surge-common
 
 # FLAGS will be passed to both the C and C++ compiler
 FLAGS += -Isurge/src/common \

--- a/src/SurgeBiquad.hpp
+++ b/src/SurgeBiquad.hpp
@@ -178,9 +178,7 @@ struct SurgeBiquad :  public SurgeModuleCommon {
                 fr = rack::clamp(fr, -60.0, 65.0); // don't allow overflows or underflows from CV
                 float res = getParam(RESO_KNOB) + inputs[RESO_CV].getPolyVoltage(i) / 10.0; // +/- 5 -> +/- 0.5
                 float xtra = getParam(THIRD_KNOB) + inputs[THIRD_CV].getPolyVoltage(i) / 10.0;
-                
-                float lightValue = 0;
-                
+
                 switch(type)
                 {
                 case LP:
@@ -210,7 +208,6 @@ struct SurgeBiquad :  public SurgeModuleCommon {
                 case peakEQ:
                 {
                     float gain = 48 * ( xtra - 0.5 );
-                    lightValue = 10;
                     biquad[i]->coeff_peakEQ(biquad[i]->calc_omega(fr/12), res, gain);
                     break;
                 }


### PR DESCRIPTION
Make sure we use $(CMAKE) properly
Don't change $CC_FLAGS before a build
And squash an irrelevant warning in the b iqyad