### PR TITLE
Temposync Started for FX; Freq Shift and Delay panels roughed

### DIFF
--- a/src/FX.cpp
+++ b/src/FX.cpp
@@ -21,15 +21,14 @@ struct FXWidget : public widgets::XTModuleWidget, widgets::StandardWidthWithModu
 
 AS you know, on the VCO's there was a 16mm vertical offset between knob rows.
 
-On the FX, where there is no group title on a row, the offset will be the same. But if there is a group title on a row, then the offset to the next row of regular sized knobs will be 20mm instead
+On the FX, where there is no group title on a row, the offset will be the same. But if there is a
+group title on a row, then the offset to the next row of regular sized knobs will be 20mm instead
 
-We will work up from the bottom, so all the 2 lower rows of jacks/mods and the first row of knobs will be in exactly the same place as on the VCOs, and we work the spacing up from there.
-In other words, having group titles on a row adds 4mm to the vertical offset
-spiritlevel — Yesterday at 5:09 PM
-So:
-16mm up to the next reg. knob row if current knob row has no group titles
-20mm up to next reg. knob row if current knob row has group titles
-Add an extra 1.5mm if next row up is medium knobs
+We will work up from the bottom, so all the 2 lower rows of jacks/mods and the first row of knobs
+will be in exactly the same place as on the VCOs, and we work the spacing up from there. In other
+words, having group titles on a row adds 4mm to the vertical offset spiritlevel — Yesterday at 5:09
+PM So: 16mm up to the next reg. knob row if current knob row has no group titles 20mm up to next
+reg. knob row if current knob row has group titles Add an extra 1.5mm if next row up is medium knobs
 Add an extra 3mm if next row up is large knobs
 
 This should work for all FX - hope that makes sense!
@@ -81,7 +80,7 @@ template <int fxType> FXWidget<fxType>::FXWidget(FXWidget<fxType>::M *module)
                 auto boxbl = rack::Vec(rack::mm2px(lay.xcmm - columnWidth_MM * 0.5),
                                        knob->box.pos.y + knob->box.size.y);
                 auto lab = widgets::Label::createWithBaselineBox(
-                    boxbl, rack::mm2px(rack::Vec(columnWidth_MM, 3.5)), lay.label);
+                    boxbl, rack::mm2px(rack::Vec(columnWidth_MM, 4)), lay.label);
                 addChild(lab);
 
                 underKnobs[lay.parId] = knob;
@@ -103,12 +102,14 @@ template <int fxType> FXWidget<fxType>::FXWidget(FXWidget<fxType>::M *module)
         case FXConfig<fxType>::LayoutItem::PORT:
         {
             auto port = rack::createInputCentered<widgets::Port>(
-                rack::mm2px(rack::Vec(lay.xcmm, lay.ycmm)), module, lay.parId);
+                rack::mm2px(rack::Vec(lay.xcmm, lay.ycmm + verticalPortOffset_MM)), module,
+                lay.parId);
             addChild(port);
             auto boxbl = rack::Vec(rack::mm2px(lay.xcmm - columnWidth_MM * 0.5),
-                                   port->box.pos.y + port->box.size.y);
+                                   port->box.pos.y + port->box.size.y +
+                                       rack::mm2px(2 * verticalPortOffset_MM));
             auto lab = widgets::Label::createWithBaselineBox(
-                boxbl, rack::mm2px(rack::Vec(columnWidth_MM, 3.5)), lay.label);
+                boxbl, rack::mm2px(rack::Vec(columnWidth_MM, 4)), lay.label);
             addChild(lab);
         }
         break;

--- a/src/FXConfig.hpp
+++ b/src/FXConfig.hpp
@@ -3,6 +3,10 @@
 
 #include "FX.hpp"
 #include "dsp/Effect.h"
+#include "XTModuleWidget.hpp"
+
+#include "dsp/effects/FrequencyShifterEffect.h"
+#include "dsp/effects/DelayEffect.h"
 
 namespace sst::surgext_rack::fx
 {
@@ -43,22 +47,60 @@ template <> void FXConfig<fxt_spring_reverb>::processExtraInputs(FX<fxt_spring_r
     }
 }
 
-// Gross hack so I can test
 template <> FXConfig<fxt_delay>::layout_t FXConfig<fxt_delay>::getLayout()
 {
-    // clang-format off
+    const auto &col = widgets::StandardWidthWithModulationConstants::columnCenters_MM;
+    const auto modRow = widgets::StandardWidthWithModulationConstants::modulationRowCenters_MM[0];
+
+    const auto thirdSmallRow = modRow - 16;
+    const auto secondSmallRow = thirdSmallRow - 16;
+    const auto firstSmallRow = secondSmallRow - 16;
+    const auto bigRow = firstSmallRow - 20;
+
     return {
-        {LayoutItem::KNOB16, "LEFT", 0, 12, 28},
-        {LayoutItem::KNOB16, "RIGHT", 1, 32, 28},
-        {LayoutItem::KNOB9, "FBACK", 2, 51.48, 20},
-        {LayoutItem::KNOB9, "XFEED", 3, 51.48, 36},
+        // clang-format off
+        {LayoutItem::KNOB12, "LEFT", DelayEffect::dly_time_left, (col[0] + col[1]) * 0.5, bigRow},
+        {LayoutItem::KNOB12, "RIGHT", DelayEffect::dly_time_right, (col[2] + col[3]) * 0.5, bigRow},
 
-        {LayoutItem::KNOB9, "WIDTH", 11, 37.48, 65},
-        {LayoutItem::KNOB9, "MIX", 10, 51.48, 65},
+        {LayoutItem::PORT, "CLOCK", FX<fxt_delay>::INPUT_CLOCK,
+            col[0], firstSmallRow },
+        {LayoutItem::KNOB9, "INPUT", DelayEffect::dly_input_channel, col[1], firstSmallRow},
+        {LayoutItem::KNOB9, "RATE", DelayEffect::dly_mod_rate, col[2], firstSmallRow},
+        {LayoutItem::KNOB9, "DEPTH", DelayEffect::dly_mod_depth, col[3], firstSmallRow},
+
+        {LayoutItem::KNOB9, "F/B", DelayEffect::dly_feedback, col[0], secondSmallRow},
+        {LayoutItem::KNOB9, "XFEED", DelayEffect::dly_crossfeed, col[1], secondSmallRow},
+        {LayoutItem::KNOB9, "LOWCUT", DelayEffect::dly_lowcut, col[2], secondSmallRow},
+        {LayoutItem::KNOB9, "HICUT", DelayEffect::dly_highcut, col[3], secondSmallRow},
+
+        {LayoutItem::KNOB9, "WIDTH", DelayEffect::dly_width, col[2], thirdSmallRow},
+        {LayoutItem::KNOB9, "MIXT", DelayEffect::dly_mix, col[3], thirdSmallRow},
+        // clang-format on
     };
-
-    // clang-format on
 }
+template <> constexpr int FXConfig<fxt_delay>::usesClock() { return true; }
+
+template <> FXConfig<fxt_freqshift>::layout_t FXConfig<fxt_freqshift>::getLayout()
+{
+    const auto &col = widgets::StandardWidthWithModulationConstants::columnCenters_MM;
+    const auto modRow = widgets::StandardWidthWithModulationConstants::modulationRowCenters_MM[0];
+
+    const auto smallRow = modRow - 16;
+    const auto bigRow = smallRow - 22;
+
+    return {
+        // clang-format off
+        {LayoutItem::PORT, "CLOCK", FX<fxt_delay>::INPUT_CLOCK,
+            col[0], smallRow },
+        {LayoutItem::KNOB9, "DELAY", FrequencyShifterEffect::freq_delay, col[1], smallRow},
+        {LayoutItem::KNOB9, "F/B", FrequencyShifterEffect::freq_feedback, col[2], smallRow},
+        {LayoutItem::KNOB9, "MIX", FrequencyShifterEffect::freq_mix, col[3], smallRow},
+        {LayoutItem::KNOB16, "LEFT", FrequencyShifterEffect::freq_shift, (col[0] + col[1]) * 0.5, bigRow},
+        {LayoutItem::KNOB16, "RIGHT", FrequencyShifterEffect::freq_rmult, (col[2] + col[3]) * 0.5, bigRow},
+        // clang-format on
+    };
+}
+template <> constexpr int FXConfig<fxt_freqshift>::usesClock() { return true; }
 
 #if 0
 // Top Row is Grouped

--- a/src/XTModule.hpp
+++ b/src/XTModule.hpp
@@ -258,6 +258,11 @@ struct SurgeParameterParamQuantity : public rack::engine::ParamQuantity
         {
             return std::string(txt) + " (" + talt + ")";
         }
+
+        if (par->temposync)
+        {
+            return std::string(txt) + " @ " + fmt::format("{:.1f}bpm", xtm()->storage->temposyncratio * 120);
+        }
         return txt;
     }
 };

--- a/src/XTModule.hpp
+++ b/src/XTModule.hpp
@@ -505,4 +505,57 @@ struct ModulationAssistant
         }
     }
 };
+
+template<typename T>
+struct ClockProcessor
+{
+    rack::dsp::SchmittTrigger trig;
+
+    float sampleRate{1}, sampleRateInv{1};
+    int timeSinceLast{-1};
+    float lastBPM{-1};
+    void setSampleRate(float sr)
+    {
+        sampleRate = sr;
+        sampleRateInv = 1.f / sr;
+    }
+    inline void process(T *m, int inputId)
+    {
+        if (trig.process(m->inputs[inputId].getVoltage()))
+        {
+            if (timeSinceLast > 0)
+            {
+                auto bpm = 60 * sampleRate / timeSinceLast;
+
+                // OK we are going to make an assumption
+                // that BPM is *probably* integral at least
+                // if we are within a smidge of an integer
+                auto d = std::abs(bpm - std::round(bpm));
+                if (d < 0.015)
+                {
+                    bpm = std::round(bpm);
+                }
+                if (bpm != lastBPM)
+                {
+                    m->storage->temposyncratio = bpm / 120.f;
+                    m->storage->temposyncratio_inv = 120.f / bpm;
+                }
+                lastBPM = bpm;
+            }
+            else
+            {
+                m->activateTempoSync();
+            }
+            timeSinceLast = 0;
+        }
+        timeSinceLast += (timeSinceLast >= 0);
+    }
+    inline void disconnect(T *m)
+    {
+        if (timeSinceLast >= 0)
+            m->deactivateTempoSync();
+
+        timeSinceLast = -1;
+    }
+};
 } // namespace sst::surgext_rack::modules

--- a/src/XTModuleWidget.hpp
+++ b/src/XTModuleWidget.hpp
@@ -1,3 +1,6 @@
+#ifndef SURGE_RACK_XTMODULEWIDGET
+#define SURGE_RACK_XTMODULEWIDGET 1
+
 #include "rack.hpp"
 #include "XTStyle.hpp"
 #include <array>
@@ -29,6 +32,7 @@ struct StandardWidthWithModulationConstants
     static constexpr float columnWidth_MM = 14;
     static constexpr float modulationLabelBaseline_MM = 94.864;
     static constexpr float inputLabelBaseline_MM = 109.203;
+    static constexpr float verticalPortOffset_MM = 0.5;
 
     static constexpr int numberOfScrews = 12;
 
@@ -77,7 +81,6 @@ struct VCOVCFConstants : StandardWidthWithModulationConstants
         55, 71, modulationRowCenters_MM[0], modulationRowCenters_MM[1], inputRowCenter_MM};
     static constexpr std::array<float, 2> labelBaselines_MM{63.573, 79.573};
 
-    static constexpr float verticalPortOffset_MM = 0.5;
 
     float plotStartX = rack::mm2px(plotCX_MM - plotW_MM * 0.5);
     float plotStartY = rack::mm2px(plotCY_MM - plotH_MM * 0.5);
@@ -95,3 +98,5 @@ struct VCOVCFConstants : StandardWidthWithModulationConstants
     }
 };
 } // namespace sst::surgext_rack::widgets
+
+#endif


### PR DESCRIPTION
1. ClockProcessor and temposync support which basically sets up tempo and temposync properly
2. Start of showing that wokring in FX but it doesn't work in the presence of modulation alas since I think the set-value-f10 does the temposync bind. But look at that later this week.