### PR TITLE
More FX come online; Fix redundant brand and module names

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "slug": "SurgeXTRack",
-  "name": "Surge XT for Rack",
+  "name": "Surge XT",
   "version": "2.xt-1.1.1",
   "license": "GPL-3.0-or-later",
   "author": "Surge Synth Team",
@@ -13,7 +13,7 @@
   "modules": [
     {
       "slug": "SurgeXTVCF",
-      "name": "SXT VCF",
+      "name": "VCF",
       "description": "The Surge Filter VCFs",
       "tags": [
         "VCF",
@@ -22,7 +22,7 @@
     },
     {
       "slug": "SurgeXTWaveshaper",
-      "name": "SXT Waveshaper",
+      "name": "Waveshaper",
       "description": "The Surge Waveshapers",
       "tags": [
         "Distortion",
@@ -32,7 +32,7 @@
     },
     {
       "slug": "SurgeXTOSCModern",
-      "name": "SXT Modern VCO",
+      "name": "Modern VCO",
       "description": "The Surge Modern Oscillator",
       "tags": [
         "VCO",
@@ -41,7 +41,7 @@
     },
     {
       "slug": "SurgeXTOSCClassic",
-      "name": "SXT Classic VCO",
+      "name": "Classic VCO",
       "description": "The Surge Classic Oscillator",
       "tags": [
         "VCO",
@@ -50,7 +50,7 @@
     },
     {
       "slug": "SurgeXTOSCWavetable",
-      "name": "SXT Wavetable VCO",
+      "name": "Wavetable VCO",
       "description": "The Surge Wavetable Oscillator",
       "tags": [
         "VCO",
@@ -59,7 +59,7 @@
     },
     {
       "slug": "SurgeXTOSCWindow",
-      "name": "SXT Window VCO",
+      "name": "Window VCO",
       "description": "The Surge Window Oscillator",
       "tags": [
         "VCO",
@@ -68,7 +68,7 @@
     },
     {
       "slug": "SurgeXTOSCSine",
-      "name": "SXT Sine VCO",
+      "name": "Sine VCO",
       "description": "The Surge Sine Oscillator",
       "tags": [
         "VCO",
@@ -77,7 +77,7 @@
     },
     {
       "slug": "SurgeXTOSCFM2",
-      "name": "SXT FM2 VCO",
+      "name": "FM2 VCO",
       "description": "The Surge FM2 Oscillator",
       "tags": [
         "VCO",
@@ -86,7 +86,7 @@
     },
     {
       "slug": "SurgeXTOSCFM3",
-      "name": "SXT FM3 VCO",
+      "name": "FM3 VCO",
       "description": "The Surge FM3 Oscillator",
       "tags": [
         "VCO",
@@ -95,7 +95,7 @@
     },
     {
       "slug": "SurgeXTOSCSHNoise",
-      "name": "SXT S&H Noise VCO",
+      "name": "S&H Noise VCO",
       "description": "The Surge S&H Noise Oscillator",
       "tags": [
         "VCO",
@@ -104,7 +104,7 @@
     },
     {
       "slug": "SurgeXTOSCAlias",
-      "name": "SXT Alias VCO",
+      "name": "Alias VCO",
       "description": "The Surge Alias Oscillator",
       "tags": [
         "VCO",
@@ -113,7 +113,7 @@
     },
     {
       "slug": "SurgeXTOSCString",
-      "name": "SXT String VCO",
+      "name": "String VCO",
       "description": "The Surge String Oscillator",
       "tags": [
         "VCO",
@@ -122,7 +122,7 @@
     },
     {
       "slug": "SurgeXTOSCTwist",
-      "name": "SXT Twist VCO",
+      "name": "Twist VCO",
       "description": "The Surge Twist Oscillator, based on a famous EuroRack module",
       "tags": [
         "VCO",
@@ -131,7 +131,7 @@
     },
     {
       "slug": "SurgeXTFXReverb",
-      "name": "SXT Reverb",
+      "name": "Reverb",
       "description": "The Surge XT Reverb",
       "tags": [
         "Effect",
@@ -140,7 +140,7 @@
     },
     {
       "slug": "SurgeXTFXPhaser",
-      "name": "SXT Phaser",
+      "name": "Phaser",
       "description": "The Surge XT Phaser",
       "tags": [
         "Effect",
@@ -149,7 +149,7 @@
     },
     {
       "slug": "SurgeXTFXRotarySpeaker",
-      "name": "SXT RotarySpeaker",
+      "name": "RotarySpeaker",
       "description": "The Surge XT RotarySpeaker",
       "tags": [
         "Effect"
@@ -157,7 +157,7 @@
     },
     {
       "slug": "SurgeXTFXDistortion",
-      "name": "SXT Distortion",
+      "name": "Distortion",
       "description": "The Surge XT Distortion",
       "tags": [
         "Effect",
@@ -166,7 +166,7 @@
     },
     {
       "slug": "SurgeXTFXFrequencyShifter",
-      "name": "SXT FrequencyShifter",
+      "name": "FrequencyShifter",
       "description": "The Surge XT FrequencyShifter",
       "tags": [
         "Effect"
@@ -174,7 +174,7 @@
     },
     {
       "slug": "SurgeXTFXChorus",
-      "name": "SXT Chorus",
+      "name": "Chorus",
       "description": "The Surge XT Chorus",
       "tags": [
         "Effect",
@@ -183,7 +183,7 @@
     },
     {
       "slug": "SurgeXTFXVocoder",
-      "name": "SXT Vocoder",
+      "name": "Vocoder",
       "description": "The Surge XT Vocoder",
       "tags": [
         "Effect",
@@ -192,7 +192,7 @@
     },
     {
       "slug": "SurgeXTFXReverb2",
-      "name": "SXT Reverb2",
+      "name": "Reverb2",
       "description": "The Surge XT Reverb2",
       "tags": [
         "Effect",
@@ -201,7 +201,7 @@
     },
     {
       "slug": "SurgeXTFXFlanger",
-      "name": "SXT Flanger",
+      "name": "Flanger",
       "description": "The Surge XT Flanger",
       "tags": [
         "Effect",
@@ -210,7 +210,7 @@
     },
     {
       "slug": "SurgeXTFXRingMod",
-      "name": "SXT RingMod",
+      "name": "RingMod",
       "description": "The Surge XT RingMod",
       "tags": [
         "Effect",
@@ -219,7 +219,7 @@
     },
     {
       "slug": "SurgeXTFXNeuron",
-      "name": "SXT Neuron",
+      "name": "Neuron",
       "description": "The Surge XT Neuron",
       "tags": [
         "Effect",
@@ -228,7 +228,7 @@
     },
     {
       "slug": "SurgeXTFXResonator",
-      "name": "SXT Resonator",
+      "name": "Resonator",
       "description": "The Surge XT Resonator",
       "tags": [
         "Effect",
@@ -237,7 +237,7 @@
     },
     {
       "slug": "SurgeXTFXChow",
-      "name": "SXT Chow",
+      "name": "Chow",
       "description": "The Surge XT Chow",
       "tags": [
         "Effect",
@@ -246,7 +246,7 @@
     },
     {
       "slug": "SurgeXTFXExciter",
-      "name": "SXT Exciter",
+      "name": "Exciter",
       "description": "The Surge XT Exciter",
       "tags": [
         "Effect"
@@ -254,7 +254,7 @@
     },
     {
       "slug": "SurgeXTFXEnsemble",
-      "name": "SXT Ensemble",
+      "name": "Ensemble",
       "description": "The Surge XT Ensemble",
       "tags": [
         "Effect",
@@ -263,7 +263,7 @@
     },
     {
       "slug": "SurgeXTFXCombulator",
-      "name": "SXT Combulator",
+      "name": "Combulator",
       "description": "The Surge XT Combulator",
       "tags": [
         "Effect",
@@ -272,7 +272,7 @@
     },
     {
       "slug": "SurgeXTFXSpringReverb",
-      "name": "SXT SpringReverb",
+      "name": "SpringReverb",
       "description": "The Surge XT SpringReverb",
       "tags": [
         "Effect",
@@ -281,7 +281,7 @@
     },
     {
       "slug": "SurgeXTLFO",
-      "name": "SXT LFO",
+      "name": "LFO",
       "description": "The Surge XT LFO",
       "tags": [
         "LFO",
@@ -290,7 +290,7 @@
     },
     {
       "slug": "SurgeXTDelay",
-      "name": "SXT Delay",
+      "name": "Delay",
       "description": "The Surge XT Delay",
       "tags": [
         "Effect",
@@ -299,7 +299,7 @@
     },
     {
       "slug": "SurgeXTDelayLineByFreq",
-      "name": "SXT Delay Line by Frequency",
+      "name": "Delay Line by Frequency",
       "description": "The Surge XT Delay Line, tuned by v/oct with sample offset for KS and so on",
       "tags": [
         "Effect",
@@ -309,7 +309,7 @@
     },
     {
       "slug": "SurgeXTMixer",
-      "name": "SXT Mixer",
+      "name": "Mixer",
       "description": "The Surge XT Mixer",
       "tags": [
         "Mixer",
@@ -318,7 +318,7 @@
     },
     {
       "slug": "SurgeXTModMatrix",
-      "name": "SXT ModMatrix",
+      "name": "ModMatrix",
       "description": "The Surge XT ModMatrix",
       "tags": [
         "Utility",
@@ -327,7 +327,7 @@
     },
     {
       "slug": "SurgeXTTreeMonster",
-      "name": "SXT TreeMonster",
+      "name": "TreeMonster",
       "description": "You'll love it. Its a way of life",
       "tags": [
         "Effect",

--- a/src/FXConfig.hpp
+++ b/src/FXConfig.hpp
@@ -59,4 +59,7 @@ struct FXLayoutHelper
 #include "fxconfig/Chow.h"
 #include "fxconfig/Flanger.h"
 #include "fxconfig/FrequencyShifter.h"
+#include "fxconfig/Ensemble.h"
+#include "fxconfig/Neuron.h"
+#include "fxconfig/Combulator.h"
 #endif

--- a/src/VCF.hpp
+++ b/src/VCF.hpp
@@ -87,7 +87,7 @@ struct VCF : public modules::XTModule
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
 
         // FIXME attach formatters here
-        configParam<modules::VOctParamQuantity<60>>(FREQUENCY, -5, 5, 0);
+        configParam<modules::VOctParamQuantity<60>>(FREQUENCY, -5, 5, 0, "Frequency");
         configParam(RESONANCE, 0, 1, sqrt(2) * 0.5, "Resonance", "%", 0.f, 100.f);
         configParam<modules::DecibelParamQuantity>(IN_GAIN, 0, 2, 1);
         configParam(MIX, 0, 1, 1, "Mix", "%", 0.f, 100.f);

--- a/src/fxconfig/Combulator.h
+++ b/src/fxconfig/Combulator.h
@@ -1,0 +1,93 @@
+//
+// Created by Paul Walker on 9/27/22.
+//
+
+#include "dsp/effects/CombulatorEffect.h"
+
+#ifndef RACK_HACK_COMBULATOR_H
+#define RACK_HACK_COMBULATOR_H
+
+namespace sst::surgext_rack::fx
+{
+
+template <> constexpr int FXConfig<fxt_combulator>::specificParamCount() { return 1; }
+template <> FXConfig<fxt_combulator>::layout_t FXConfig<fxt_combulator>::getLayout()
+{
+    const auto &col = widgets::StandardWidthWithModulationConstants::columnCenters_MM;
+    const auto modRow = widgets::StandardWidthWithModulationConstants::modulationRowCenters_MM[0];
+
+    const auto row3 = FXLayoutHelper::rowStart_MM;
+    const auto row2 = row3 - FXLayoutHelper::labeledGap_MM;
+    const auto row1 = row2 - FXLayoutHelper::labeledGap_MM;
+
+    typedef FX<fxt_combulator> fx_t;
+    typedef CombulatorEffect c_t;
+
+    // clang-format off
+    return {
+        {LayoutItem::KNOB9, "NOISE IN", c_t::combulator_noise_mix, col[0], row1},
+        {LayoutItem::KNOB9, "CENTER", c_t::combulator_freq1, col[1], row1},
+        {LayoutItem::KNOB9, "", c_t::combulator_freq2, col[2], row1},
+        {LayoutItem::KNOB9, "", c_t::combulator_freq3, col[3], row1},
+        LayoutItem::createKnobSpanLabel("1 - OFFSET - 2", col[2], row1, 2),
+        LayoutItem::createGrouplabel("FREQUENCY", col[1], row1, 3),
+
+        {LayoutItem::KNOB9, "FBACK", c_t::combulator_feedback, col[0], row2},
+        {LayoutItem::KNOB9, "COMB1", c_t::combulator_gain1, col[1], row2},
+        {LayoutItem::KNOB9, "COMB2", c_t::combulator_gain2, col[2], row2},
+        {LayoutItem::KNOB9, "COMB3", c_t::combulator_gain3, col[3], row2},
+        LayoutItem::createGrouplabel("LEVEL", col[1], row2, 3),
+
+        {LayoutItem::KNOB9, "TONE", c_t::combulator_tone, col[0], row3},
+        {LayoutItem::POWER_LIGHT, "", fx_t::FX_SPECIFIC_PARAM_0, col[0], row3, 1},
+
+
+        {LayoutItem::KNOB9, "PAN2", c_t::combulator_pan2, col[1], row3},
+        {LayoutItem::KNOB9, "PAN3", c_t::combulator_pan3, col[2], row3},
+        {LayoutItem::KNOB9, "MIX", c_t::combulator_mix, col[3], row3},
+        LayoutItem::createGrouplabel("OUTPUT", col[1], row3, 3),
+
+        LayoutItem::createPresetLCDArea(),
+    };
+    // clang-format on
+}
+
+template <> void FXConfig<fxt_combulator>::configSpecificParams(FX<fxt_combulator> *m)
+{
+    typedef FX<fxt_combulator> fx_t;
+    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1, "Enable Tone Filter");
+}
+
+template <> void FXConfig<fxt_combulator>::processSpecificParams(FX<fxt_combulator> *m)
+{
+    typedef FX<fxt_combulator> fx_t;
+    {
+        auto drOff = m->fxstorage->p[CombulatorEffect::combulator_tone].deactivated;
+        auto parVa = m->params[fx_t::FX_SPECIFIC_PARAM_0].getValue() > 0.5;
+        if (parVa != (!drOff))
+        {
+            m->fxstorage->p[CombulatorEffect::combulator_tone].deactivated = !parVa;
+        }
+    }
+}
+
+template <>
+void FXConfig<fxt_combulator>::loadPresetOntoSpecificParams(
+    FX<fxt_combulator> *m, const Surge::Storage::FxUserPreset::Preset &ps)
+{
+    typedef FX<fxt_combulator> fx_t;
+    typedef CombulatorEffect sx_t;
+    m->params[fx_t::FX_SPECIFIC_PARAM_0].setValue(ps.da[sx_t::combulator_tone] ? 0 : 1);
+}
+
+template <>
+bool FXConfig<fxt_combulator>::isDirtyPresetVsSpecificParams(
+    FX<fxt_combulator> *m, const Surge::Storage::FxUserPreset::Preset &ps)
+{
+    typedef FX<fxt_combulator> fx_t;
+    typedef CombulatorEffect sx_t;
+    auto p0 = m->params[fx_t::FX_SPECIFIC_PARAM_0].getValue() > 0.5;
+    return !(p0 == !ps.da[sx_t::combulator_tone]);
+}
+} // namespace sst::surgext_rack::fx
+#endif // RACK_HACK_ROTARYSPEAKER_H

--- a/src/fxconfig/Distortion.h
+++ b/src/fxconfig/Distortion.h
@@ -88,8 +88,9 @@ void FXConfig<fxt_distortion>::loadPresetOntoSpecificParams(
     FX<fxt_distortion> *m, const Surge::Storage::FxUserPreset::Preset &ps)
 {
     typedef FX<fxt_distortion> fx_t;
-    typedef RotarySpeakerEffect sx_t;
-    m->params[fx_t::FX_SPECIFIC_PARAM_0].setValue(ps.da[sx_t::rot_drive] ? 0 : 1);
+    typedef DistortionEffect sx_t;
+    m->params[fx_t::FX_SPECIFIC_PARAM_0].setValue(ps.da[sx_t::dist_preeq_highcut] ? 0 : 1);
+    m->params[fx_t::FX_SPECIFIC_PARAM_0 + 1].setValue(ps.da[sx_t::dist_posteq_highcut] ? 0 : 1);
 }
 
 template <>
@@ -97,9 +98,10 @@ bool FXConfig<fxt_distortion>::isDirtyPresetVsSpecificParams(
     FX<fxt_distortion> *m, const Surge::Storage::FxUserPreset::Preset &ps)
 {
     typedef FX<fxt_distortion> fx_t;
-    typedef RotarySpeakerEffect sx_t;
+    typedef DistortionEffect sx_t;
     auto p0 = m->params[fx_t::FX_SPECIFIC_PARAM_0].getValue() > 0.5;
-    return !(p0 == !ps.da[sx_t::rot_drive]);
+    auto p1 = m->params[fx_t::FX_SPECIFIC_PARAM_0 + 1].getValue() > 0.5;
+    return !((p0 == !ps.da[sx_t::dist_preeq_highcut]) && (p1 == !ps.da[sx_t::dist_posteq_highcut]));
 }
 } // namespace sst::surgext_rack::fx
 #endif // RACK_HACK_ROTARYSPEAKER_H

--- a/src/fxconfig/Ensemble.h
+++ b/src/fxconfig/Ensemble.h
@@ -1,0 +1,56 @@
+//
+// Created by Paul Walker on 9/27/22.
+//
+
+#include "dsp/effects/BBDEnsembleEffect.h"
+
+#ifndef RACK_HACK_ENSEMBLE_H
+#define RACK_HACK_ENSEMBLE_H
+
+namespace sst::surgext_rack::fx
+{
+
+/*
+ */
+template <> FXConfig<fxt_ensemble>::layout_t FXConfig<fxt_ensemble>::getLayout()
+{
+    const auto &col = widgets::StandardWidthWithModulationConstants::columnCenters_MM;
+    const auto modRow = widgets::StandardWidthWithModulationConstants::modulationRowCenters_MM[0];
+
+    const auto row3 = FXLayoutHelper::rowStart_MM;
+    const auto row2 = row3 - FXLayoutHelper::labeledGap_MM;
+    const auto row1 = row2 - FXLayoutHelper::labeledGap_MM;
+
+    const auto col15 = (col[0] + col[1]) * 0.5f;
+
+    // ToDo: On Off for drive and Rrive as a selected type
+    typedef FX<fxt_ensemble> fx_t;
+
+    // clang-format off
+    return {
+        {LayoutItem::KNOB9, "RATE", BBDEnsembleEffect::ens_lfo_freq1, col[0], row1},
+        {LayoutItem::KNOB9, "DEPTH", BBDEnsembleEffect::ens_lfo_depth1, col[1], row1},
+        LayoutItem::createGrouplabel("LFO1", col[0], row1, 2),
+        {LayoutItem::KNOB9, "RATE", BBDEnsembleEffect::ens_lfo_freq2, col[2], row1},
+        {LayoutItem::KNOB9, "DEPTH", BBDEnsembleEffect::ens_lfo_depth2, col[3], row1},
+        LayoutItem::createGrouplabel("LFO2", col[2], row1, 2),
+
+        {LayoutItem::KNOB9, "FILTER", BBDEnsembleEffect::ens_input_filter, col[0], row2},
+        LayoutItem::createGrouplabel("INPUT", col[0], row2, 1),
+        {LayoutItem::KNOB9, "RATE", BBDEnsembleEffect::ens_delay_clockrate, col[1], row2},
+        {LayoutItem::KNOB9, "SAT", BBDEnsembleEffect::ens_delay_sat, col[2], row2},
+        {LayoutItem::KNOB9, "FDBACK", BBDEnsembleEffect::ens_delay_feedback, col[3], row2},
+        LayoutItem::createGrouplabel("DELAY", col[1], row2, 3),
+
+        {LayoutItem::KNOB9, "WIDTH", BBDEnsembleEffect::ens_width, col[2], row3},
+        {LayoutItem::KNOB9, "MIX", BBDEnsembleEffect::ens_mix, col[3], row3},
+        LayoutItem::createGrouplabel("OUTPUT", col[2], row3, 2),
+
+        LayoutItem::createPresetPlusOneArea(),
+        LayoutItem::createSingleMenuItem("TYPE", BBDEnsembleEffect::ens_delay_type)
+    };
+    // clang-format on
+}
+
+} // namespace sst::surgext_rack::fx
+#endif // RACK_HACK_ROTARYSPEAKER_H

--- a/src/fxconfig/Neuron.h
+++ b/src/fxconfig/Neuron.h
@@ -1,0 +1,79 @@
+//
+// Created by Paul Walker on 9/27/22.
+//
+
+// Because of JUCE we can't include this here currently
+// #include "dsp/effects/chowdsp/NeuronEffect.h"
+
+#ifndef RACK_HACK_NEURON_H
+#define RACK_HACK_NEURON_H
+
+namespace sst::surgext_rack::fx
+{
+
+// So because of that include copy the enum
+enum n_t
+{
+    neuron_drive_wh = 0,
+    neuron_squash_wf,
+    neuron_stab_uf,
+    neuron_asym_uh,
+    neuron_bias_bf,
+
+    neuron_comb_freq,
+    neuron_comb_sep,
+
+    neuron_lfo_wave,
+    neuron_lfo_rate,
+    neuron_lfo_depth,
+
+    neuron_width,
+    neuron_gain,
+
+    neuron_num_params,
+};
+
+/*
+ */
+template <> constexpr bool FXConfig<fxt_neuron>::usesClock() { return true; }
+template <> FXConfig<fxt_neuron>::layout_t FXConfig<fxt_neuron>::getLayout()
+{
+    const auto &col = widgets::StandardWidthWithModulationConstants::columnCenters_MM;
+    const auto modRow = widgets::StandardWidthWithModulationConstants::modulationRowCenters_MM[0];
+
+    const auto row3 = FXLayoutHelper::rowStart_MM;
+    const auto row2 = row3 - FXLayoutHelper::labeledGap_MM;
+    const auto row1 = row2 - FXLayoutHelper::labeledGap_MM;
+
+    // ToDo: On Off for drive and Rrive as a selected type
+    typedef FX<fxt_neuron> fx_t;
+
+    // clang-format off
+    return {
+        {LayoutItem::KNOB9, "DRIVE", n_t::neuron_drive_wh, col[0], row1},
+        {LayoutItem::KNOB9, "SQUASH", n_t::neuron_squash_wf, col[1], row1},
+        {LayoutItem::KNOB9, "STAB", n_t::neuron_stab_uf, col[2], row1},
+        {LayoutItem::KNOB9, "ASYM", n_t::neuron_asym_uh, col[3], row1},
+
+        {LayoutItem::PORT, "CLOCK", fx_t::INPUT_CLOCK, col[0], row2},
+        {LayoutItem::KNOB9, "RATE", n_t::neuron_lfo_rate, col[1], row2},
+        {LayoutItem::KNOB9, "DEPTH", n_t::neuron_lfo_depth, col[2], row2},
+        LayoutItem::createGrouplabel("MOD", col[0], row2, 3),
+        {LayoutItem::KNOB9, "BIAS", n_t::neuron_bias_bf, col[3], row2},
+
+        {LayoutItem::KNOB9, "FREQ", n_t::neuron_comb_freq, col[0], row3},
+        {LayoutItem::KNOB9, "SEP", n_t::neuron_comb_sep, col[1], row3},
+        LayoutItem::createGrouplabel("COMB", col[0], row3, 2),
+
+        {LayoutItem::KNOB9, "WIDTH", n_t::neuron_width, col[2], row3},
+        {LayoutItem::KNOB9, "GAIN", n_t::neuron_gain, col[3], row3},
+        LayoutItem::createGrouplabel("OUTPUT", col[2], row3, 2),
+
+        LayoutItem::createPresetPlusOneArea(),
+        LayoutItem::createSingleMenuItem("WAVE", n_t::neuron_lfo_wave)
+    };
+    // clang-format on
+}
+
+} // namespace sst::surgext_rack::fx
+#endif // RACK_HACK_ROTARYSPEAKER_H


### PR DESCRIPTION
- Combulator, Neuron done
- Ensemble has a faceplate but not super happy with it
- Frequency parameter on VCF is now named (duh)
- Brand changes to "Surge XT" and lose the "SXT" from all the modules