### PR TITLE
A crash avoidance; some labels; start of poly FX

### DIFF
--- a/src/FX.cpp
+++ b/src/FX.cpp
@@ -26,6 +26,18 @@ template <int fxType> struct FXWidget : public widgets::XTModuleWidget
         if (!module)
             return;
         auto xtm = static_cast<FX<fxType> *>(module);
+
+        if constexpr (false && FXConfig<fxType>::allowsPolyphony())
+        {
+            menu->addChild(new rack::ui::MenuSeparator);
+            bool t = xtm->polyphonicMode;
+            menu->addChild(rack::createMenuItem("Monophonic Stereo Processing", CHECKMARK(!t),
+                                                [xtm] { xtm->polyphonicMode = false; }));
+
+            menu->addChild(rack::createMenuItem("Polyphonic Stereo Processing", CHECKMARK(t),
+                                                [xtm] { xtm->polyphonicMode = true; }));
+        }
+
         if (FXConfig<fxType>::usesClock())
         {
             typedef modules::ClockProcessor<FX<fxType>> cp_t;

--- a/src/VCF.hpp
+++ b/src/VCF.hpp
@@ -89,9 +89,9 @@ struct VCF : public modules::XTModule
         // FIXME attach formatters here
         configParam<modules::VOctParamQuantity<60>>(FREQUENCY, -4, 6, 0, "Frequency");
         configParam(RESONANCE, 0, 1, sqrt(2) * 0.5, "Resonance", "%", 0.f, 100.f);
-        configParam<modules::DecibelParamQuantity>(IN_GAIN, 0, 2, 1);
+        configParam<modules::DecibelParamQuantity>(IN_GAIN, 0, 2, 1, "Pre-Filter Gain");
         configParam(MIX, 0, 1, 1, "Mix", "%", 0.f, 100.f);
-        configParam<modules::DecibelParamQuantity>(OUT_GAIN, 0, 2, 1);
+        configParam<modules::DecibelParamQuantity>(OUT_GAIN, 0, 2, 1, "Gain");
 
         configParam<VCFTypeParamQuanity>(VCF_TYPE, 0, sst::filters::num_filter_types,
                                          sst::filters::fut_obxd_4pole);

--- a/src/VCO.hpp
+++ b/src/VCO.hpp
@@ -125,15 +125,17 @@ template <int oscType> struct VCO : public modules::XTModule
 
         auto config_osc = spawn_osc(oscType, storage.get(), oscstorage,
                                     storage->getPatch().scenedata[0], oscdisplaybuffer[0]);
-        config_osc->init(72.0);
         config_osc->init_ctrltypes();
         config_osc->init_default_values();
+        config_osc->init_extra_config();
+        config_osc->init(72.0);
 
         auto display_osc = spawn_osc(oscType, storage.get(), oscstorage_display,
                                      storage->getPatch().scenedata[0], oscdisplaybuffer[1]);
-        display_osc->init(72.0, true);
         display_osc->init_ctrltypes();
         display_osc->init_default_values();
+        display_osc->init_extra_config();
+        display_osc->init(72.0, true);
 
         VCOConfig<oscType>::oscillatorSpecificSetup(this);
 
@@ -404,7 +406,6 @@ template <int oscType> struct VCO : public modules::XTModule
                                              storage->getPatch().scenedata[0], oscbuffer[c]);
 
                     surge_osc[c]->init(pitch0);
-                    surge_osc[c]->init_ctrltypes();
                 }
                 else
                 {

--- a/src/Waveshaper.hpp
+++ b/src/Waveshaper.hpp
@@ -85,8 +85,8 @@ struct Waveshaper : public modules::XTModule
         configParam(DRIVE, -24, 24, 0, "Drive", "dB"); // UNITS
         configParam(BIAS, -1, 1, 0, "Bias");
         configParam<modules::DecibelParamQuantity>(OUT_GAIN, 0, 2, 1, "Gain");
-        configParam(LOCUT, -60, 70, -60);
-        configParam(HICUT, -60, 70, 70);
+        configParam(LOCUT, -60, 70, -60, "Low Cut");
+        configParam(HICUT, -60, 70, 70, "High Cut");
         configParam(LOCUT_ENABLED, 0, 1, 0);
         configParam(HICUT_ENABLED, 0, 1, 0);
 


### PR DESCRIPTION
1. A crash avoidance in the VCO where we had init and init types out of order in the ctor
2. Labels on all the knobs in the VCF/WS. Addresses #439
3. Start on FX Poly support but leave the menu off. Addresses #451