### PR TITLE
Fix a Lin/Win error; fix Lin warnings

### DIFF
--- a/src/DelayLineByFreq.cpp
+++ b/src/DelayLineByFreq.cpp
@@ -19,14 +19,10 @@ struct DelayLineByFreqWidget : widgets::XTModuleWidget
 DelayLineByFreqWidget::DelayLineByFreqWidget(DelayLineByFreqWidget::M *module) : XTModuleWidget()
 {
     setModule(module);
-    box.size = rack::Vec(rack::app::RACK_GRID_WIDTH * 6, rack::app::RACK_GRID_HEIGHT);
-  
-#if 0
-    typedef layout::LayoutEngine<DelayLineByFreqWidget, M::VOCT> engine_t;
 
     box.size = rack::Vec(rack::app::RACK_GRID_WIDTH * 6, rack::app::RACK_GRID_HEIGHT);
-    // auto bg = new widgets::Background(box.size, "DelayLineByFreq", "other", "DelayLineByFreq");
-    // addChild(bg);
+    auto bg = new widgets::Background(box.size, "DelayLineByFreq", "other", "DelayLineByFreq");
+    addChild(bg);
 
     {
         auto cx = box.size.x * 0.5;
@@ -105,7 +101,6 @@ DelayLineByFreqWidget::DelayLineByFreqWidget(DelayLineByFreqWidget::M *module) :
     }
 
     resetStyleCouplingToModule();
-#endif
 }
 } // namespace sst::surgext_rack::delay::ui
 

--- a/src/FX.hpp
+++ b/src/FX.hpp
@@ -409,7 +409,7 @@ template <int fxType> struct FX : modules::XTModule
                 FXConfig<fxType>::processSpecificParams(this);
             }
 
-            for (int i = 0; i < n_fx_params; ++i)
+            for (int i = 0; i < FXConfig<fxType>::numParams(); ++i)
             {
                 fxstorage->p[i].set_value_f01(modAssist.basevalues[i]);
             }
@@ -419,7 +419,7 @@ template <int fxType> struct FX : modules::XTModule
             copyGlobaldataSubset(storage_id_start, storage_id_end);
 
             auto *oap = &fxstorage->p[0];
-            auto *eap = &fxstorage->p[n_fx_params - 1];
+            auto *eap = &fxstorage->p[FXConfig<fxType>::numParams() - 1];
             auto &pt = storage->getPatch().globaldata;
             int idx = 0;
             while (oap <= eap)
@@ -523,7 +523,7 @@ template <int fxType> struct FX : modules::XTModule
                 FXConfig<fxType>::processSpecificParams(this);
             }
 
-            for (int i = 0; i < n_fx_params; ++i)
+            for (int i = 0; i < FXConfig<fxType>::numParams(); ++i)
             {
                 fxstorage->p[i].set_value_f01(polyModAssist.basevalues[i]);
             }
@@ -544,7 +544,7 @@ template <int fxType> struct FX : modules::XTModule
                 copyGlobaldataSubset(storage_id_start, storage_id_end);
 
                 auto *oap = &fxstorage->p[0];
-                auto *eap = &fxstorage->p[n_fx_params - 1];
+                auto *eap = &fxstorage->p[FXConfig<fxType>::numParams() - 1];
                 auto &pt = storage->getPatch().globaldata;
                 int idx = 0;
                 while (oap <= eap)

--- a/src/LFO.cpp
+++ b/src/LFO.cpp
@@ -25,15 +25,12 @@ LFOWidget::LFOWidget(LFOWidget::M *module) : XTModuleWidget()
     setModule(module);
     int screwWidth = 21;
     box.size = rack::Vec(rack::app::RACK_GRID_WIDTH * screwWidth, rack::app::RACK_GRID_HEIGHT);
- 
-#if 0
+
     typedef layout::LayoutEngine<LFOWidget, M::RATE> engine_t;
     engine_t::initializeModulationToBlank(this);
 
-    int screwWidth = 21;
-    box.size = rack::Vec(rack::app::RACK_GRID_WIDTH * screwWidth, rack::app::RACK_GRID_HEIGHT);
-    // auto bg = new widgets::Background(box.size, "LFO", "other", "LFO");
-    // addChild(bg);
+    auto bg = new widgets::Background(box.size, "LFO", "other", "LFO");
+    addChild(bg);
 
     typedef layout::LayoutItem li_t;
 
@@ -164,7 +161,6 @@ LFOWidget::LFOWidget(LFOWidget::M *module) : XTModuleWidget()
     engine_t::addModulationSection(this, M::n_mod_inputs, M::LFO_MOD_INPUT);
 
     resetStyleCouplingToModule();
-#endif
 }
 } // namespace sst::surgext_rack::lfo::ui
 

--- a/src/LFO.hpp
+++ b/src/LFO.hpp
@@ -21,7 +21,7 @@ namespace sst::surgext_rack::lfo
 struct LFO : modules::XTModule
 {
     static constexpr int n_lfo_params{10};
-    static constexpr int n_mod_inputs{5};
+    static constexpr int n_mod_inputs{4};
     static constexpr int n_arbitrary_switches{4};
 
     enum ParamIds
@@ -74,12 +74,11 @@ struct LFO : modules::XTModule
     LFO() : XTModule()
     {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
-        // setupSurge();
+        setupSurge();
     }
     
     std::string getName() override { return "LFO"; }
 
-#if 0
     std::array<std::unique_ptr<LFOModulationSource>, MAX_POLY> surge_lfo;
     std::unique_ptr<StepSequencerStorage> surge_ss;
     std::unique_ptr<MSEGStorage> surge_ms;
@@ -263,7 +262,7 @@ struct LFO : modules::XTModule
             outputI.store(outputs[OUTPUT_MIX].getVoltages(c));
         }
     }
-#endif
+
 };
 } // namespace sst::surgext_rack::lfo
 #endif // RACK_HACK_LFO_HPP

--- a/src/VCF.hpp
+++ b/src/VCF.hpp
@@ -559,6 +559,7 @@ struct VCF : public modules::XTModule
                 break;
             }
         }
+        return "Error";
     }
 };
 

--- a/src/XTStyle.cpp
+++ b/src/XTStyle.cpp
@@ -280,6 +280,8 @@ NVGcolor XTStyle::lightColorColor(sst::surgext_rack::style::XTStyle::LightColor 
     case RED:
         return nvgRGB(240, 67, 67);
     }
+
+    return nvgRGB(255,0,1);
 }
 std::map<std::string, int> InternalFontMgr::fontMap;
 

--- a/src/fxconfig/Ensemble.h
+++ b/src/fxconfig/Ensemble.h
@@ -23,8 +23,6 @@ template <> FXConfig<fxt_ensemble>::layout_t FXConfig<fxt_ensemble>::getLayout()
     const auto row2 = row3 - FXLayoutHelper::labeledGap_MM;
     const auto row1 = row2 - FXLayoutHelper::labeledGap_MM - (14 - 9) * 0.5f;
 
-    typedef FX<fxt_ensemble> fx_t;
-
     // clang-format off
     return {
         {LayoutItem::KNOB12, "LFO RATE 1",  BBDEnsembleEffect::ens_lfo_freq1, FXLayoutHelper::bigCol0, row1},


### PR DESCRIPTION
1. Fix an error where LFO thought it had 5 mod inputs which led to an OOB on WIN/LIN which crashed module browser. Closes #457

2. Fix some memory/pointer bounds warnings from gcc which were spot on.