### PR TITLE
FM3 moves Absolute to Module Menu

### DIFF
--- a/src/VCO.cpp
+++ b/src/VCO.cpp
@@ -22,6 +22,15 @@ template <int oscType> struct VCOWidget : public widgets::XTModuleWidget
         if (toggles[mod])
             toggles[mod]->onToggle(!toggles[mod]->pressedState);
     }
+
+    virtual void appendModuleSpecificMenu(rack::ui::Menu *menu) override
+    {
+        if (module)
+        {
+            auto m = static_cast<M *>(module);
+            VCOConfig<oscType>::addMenuItems(m, menu);
+        }
+    }
 };
 
 template <int oscType> struct WavetableSelector : widgets::PresetJogSelector

--- a/src/VCO.hpp
+++ b/src/VCO.hpp
@@ -20,6 +20,8 @@ template <int oscType> struct VCOConfig
         return {
         };
     }
+    // Note if you add stuff, add a separator first please
+    static void addMenuItems(VCO<oscType> *m, rack::ui::Menu *toThis) {}
 
     static constexpr bool supportsUnison() { return false; }
     static constexpr int maximumUnison() { return 9; }

--- a/src/XTModule.hpp
+++ b/src/XTModule.hpp
@@ -286,6 +286,8 @@ struct SurgeParameterParamQuantity : public rack::engine::ParamQuantity
         par->get_display_alt(talt, true, getValue());
         if (strlen(talt))
         {
+            if (std::string(talt) == " ")
+                return std::string(txt);
             return std::string(txt) + " (" + talt + ")";
         }
 

--- a/src/vcoconfig/FM3.h
+++ b/src/vcoconfig/FM3.h
@@ -16,14 +16,12 @@ template <> VCOConfig<ot_FM3>::layout_t VCOConfig<ot_FM3>::getLayout()
         LayoutItem::createVCOKnob(cp + 6, "FEEDBACK", 0, 1),
         LayoutItem::createVCOKnob(cp + 0, "", 0, 2),
         LayoutItem::createVCOKnob(cp + 1, "", 0, 3),
-        LayoutItem::createVCOLight(LayoutItem::ABSOLUTE_LIGHT, M::ARBITRARY_SWITCH_0, 0, 3),
 
         LayoutItem::createVCOSpanLabel("AMT - M1 - RATIO", 0, 2, 2),
 
         LayoutItem::createVCOKnob(cp + 2, "", 1, 0),
         LayoutItem::createVCOKnob(cp + 3, "", 1, 1),
-        LayoutItem::createVCOLight(LayoutItem::ABSOLUTE_LIGHT, M::ARBITRARY_SWITCH_0 + 1, 1, 1),
-        LayoutItem::createVCOSpanLabel("AMT - M2 - RATIO", 1, 2, 2),
+        LayoutItem::createVCOSpanLabel("AMT - M2 - RATIO", 1, 0, 2),
 
         LayoutItem::createVCOKnob(cp + 4, "", 1, 2),
         LayoutItem::createVCOKnob(cp + 5, "", 1, 3),
@@ -45,6 +43,21 @@ template <> void VCOConfig<ot_FM3>::processLightParameters(VCO<ot_FM3> *m)
         if (l1 != s->p[FM3Oscillator::fm3_m2ratio].absolute)
             s->p[FM3Oscillator::fm3_m2ratio].absolute = l1;
     }
+}
+
+template <> void VCOConfig<ot_FM3>::addMenuItems(VCO<ot_FM3> *m, rack::ui::Menu *toThis)
+{
+    toThis->addChild(new rack::ui::MenuSeparator);
+
+    auto l0 = (bool)(m->params[VCO<ot_FM3>::ARBITRARY_SWITCH_0 + 0].getValue() > 0.5);
+    toThis->addChild(rack::createMenuItem(("M1 Absolute"), CHECKMARK(l0), [m, l0]() {
+        m->params[VCO<ot_FM3>::ARBITRARY_SWITCH_0 + 0].setValue(!l0);
+    }));
+
+    auto l1 = (bool)(m->params[VCO<ot_FM3>::ARBITRARY_SWITCH_0 + 1].getValue() > 0.5);
+    toThis->addChild(rack::createMenuItem(("M2 Absolute"), CHECKMARK(l1), [m, l1]() {
+        m->params[VCO<ot_FM3>::ARBITRARY_SWITCH_0 + 1].setValue(!l1);
+    }));
 }
 
 } // namespace sst::surgext_rack::vco


### PR DESCRIPTION
- FM3 moves absolute to module menu, not a light, but also:
- VCOs can add custom items to the module menu from config

Addresses #440