### PR TITLE
Setup scene/global data in init stage

### DIFF
--- a/src/FX.hpp
+++ b/src/FX.hpp
@@ -172,6 +172,8 @@ template <int fxType> struct FX : modules::XTModule
         fxstorage = &(storage->getPatch().fx[0]);
         fxstorage->type.val.i = fxType;
 
+        copyGlobaldataSubset(storage_id_start, storage_id_end);
+
         surge_effect.reset(
             spawn_effect(fxType, storage.get(), fxstorage, storage->getPatch().globaldata));
         surge_effect->init();

--- a/src/VCO.hpp
+++ b/src/VCO.hpp
@@ -132,6 +132,7 @@ template <int oscType> struct VCO : public modules::XTModule
 
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
 
+        copyScenedataSubset(0, storage_id_start, storage_id_end);
         auto config_osc = spawn_osc(oscType, storage.get(), oscstorage,
                                     storage->getPatch().scenedata[0], oscdisplaybuffer[0]);
         config_osc->init_ctrltypes();


### PR DESCRIPTION
My theory for the clasic crash in #462 is that our params are good but our scenedata isn't when we init. Note that the line which is crashing (230 in classic) refers to the localcopy on the get extended and that won't be initialized without this, so I think it is really it.