### PR TITLE
Delay Line Bypass and PolySum (for mono delay)

### DIFF
--- a/src/Delay.h
+++ b/src/Delay.h
@@ -187,6 +187,9 @@ struct Delay : modules::XTModule
         hpPost->suspend();
 
         modulationAssistant.initialize(this);
+
+        configBypass(INPUT_L, OUTPUT_L);
+        configBypass(INPUT_R, OUTPUT_R);
     }
     std::string getName() override { return "Delay"; }
 
@@ -255,8 +258,8 @@ struct Delay : modules::XTModule
             }
         }
         modulationAssistant.updateValues(this);
-        auto il = inputs[INPUT_L].getVoltage() * RACK_TO_SURGE_OSC_MUL;
-        auto ir = inputs[INPUT_R].getVoltage() * RACK_TO_SURGE_OSC_MUL;
+        auto il = inputs[INPUT_L].getVoltageSum() * RACK_TO_SURGE_OSC_MUL;
+        auto ir = inputs[INPUT_R].getVoltageSum() * RACK_TO_SURGE_OSC_MUL;
 
         modVal += dMod;
 

--- a/src/DelayLineByFreq.h
+++ b/src/DelayLineByFreq.h
@@ -69,6 +69,15 @@ struct DelayLineByFreq : modules::XTModule
             lineL[i] = std::make_unique<SSESincDelayLine<delayLineLength>>(storage->sinctable);
             lineR[i] = std::make_unique<SSESincDelayLine<delayLineLength>>(storage->sinctable);
         }
+
+        configInput(INPUT_L, "In Left");
+        configInput(INPUT_R, "In Right");
+        configInput(INPUT_VOCT, "Delay Time as Frequency in v/oct");
+        configInput(OUTPUT_L, "Out Left");
+        configInput(OUTPUT_R, "Out Right");
+
+        configBypass(INPUT_L, OUTPUT_L);
+        configBypass(INPUT_R, OUTPUT_R);
     }
     std::string getName() override { return "DelayLineByFreq"; }
 


### PR DESCRIPTION
- Delays label inputs and outputs
- Mono-delay has PolySum on input
- Both delays implement bypass

Addresses #511