### PR TITLE
Fix modulation display; menu checkmark

### DIFF
--- a/src/VCO.cpp
+++ b/src/VCO.cpp
@@ -991,7 +991,7 @@ VCOWidget<oscType>::VCOWidget(VCOWidget<oscType>::M *module) : XTModuleWidget()
             if (!pq)
                 return;
 
-            auto &surgePar = vcm->oscstorage->p[VCOConfig<oscType>::rightMenuParamId()];
+            auto &surgePar = vcm->oscstorage_display->p[VCOConfig<oscType>::rightMenuParamId()];
             if (!(surgePar.valtype == vt_int))
                 return;
 


### PR DESCRIPTION
Modulation Display was mis-normalized so only percentages gave accurate tooltips or from strings. Correct. Closes #516

Also we used the wrong storage to set checkmarks on the VCO panel. Fixed too.