### PR TITLE
Three super minor tweaks

### DIFF
--- a/src/Delay.h
+++ b/src/Delay.h
@@ -131,7 +131,7 @@ struct Delay : modules::XTModule
                 auto tl = m->storage->note_to_pitch_ignoring_tuning(12 * v);
                 tl = std::clamp(m->storage->samplerate * tl, 0.f, delayLineLength * 1.f) *
                      m->storage->samplerate_inv;
-                return fmt::format("{:6.2f} s", tl);
+                return fmt::format("{:7.3f} s", tl);
             }
             return "ERROR";
         }

--- a/src/VCF.cpp
+++ b/src/VCF.cpp
@@ -634,8 +634,9 @@ VCFWidget::VCFWidget(VCFWidget::M *module) : XTModuleWidget()
                                         module);
     addChild(fpw);
 
-    auto subType = VCFSubtypeSelector::create(rack::Vec(plotStartX, underPlotStartY),
-                                              rack::Vec(plotW, underPlotH), module, M::VCF_SUBTYPE);
+    auto subType =
+        VCFSubtypeSelector::create(rack::Vec(plotStartX, underPlotStartY),
+                                   rack::Vec(plotW, fivemm - halfmm), module, M::VCF_SUBTYPE);
     addChild(subType);
 
     typedef layout::LayoutItem lay_t;

--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -1831,7 +1831,7 @@ struct VerticalSliderModulator : rack::SliderKnob, style::StyleParticipant, HasB
         auto hp = underlyerParamWidget->handle->box.pos;
         auto hs = underlyerParamWidget->handle->box.size;
 
-        for (const auto [v,h,c] :{ std::make_tuple(mp,mp-np, style::XTStyle::KNOB_MOD_PLUS),
+        for (const auto &[v,h,c] :{ std::make_tuple(mp,mp-np, style::XTStyle::KNOB_MOD_PLUS),
                         std::make_tuple(dp, np-dp,style::XTStyle::KNOB_MOD_MINUS)
             })
         {


### PR DESCRIPTION
1. Delay time gets 3 decimals. Closes #533
2. LFO subtype gets the right height so the right arrows.
3. A const & to avoid a copy in XTWidgets