### PR TITLE
Avoid a crash when mis-installed

### DIFF
--- a/src/VCO.cpp
+++ b/src/VCO.cpp
@@ -429,6 +429,12 @@ struct OSCPlotWidget : public rack::widget::TransparentWidget, style::StyleParti
     {
         oscPath.clear();
 
+        if (VCOConfig<oscType>::requiresWavetables())
+        {
+            if (module->wavetableCount == 0)
+                return;
+        }
+
         if (module && module->draw3DWavetable)
         {
             auto wtlockguard = std::lock_guard<std::mutex>(module->storage->waveTableDataMutex);
@@ -568,7 +574,9 @@ struct OSCPlotWidget : public rack::widget::TransparentWidget, style::StyleParti
 
     void drawPlotBackground(NVGcontext *vg)
     {
-        if (module && VCOConfig<oscType>::requiresWavetables() && module->draw3DWavetable)
+        if (module && VCOConfig<oscType>::requiresWavetables() &&
+            module->draw3DWavetable &&
+            module->wavetableCount > 0)
         {
             draw3DBackground(vg);
         }

--- a/src/VCO.h
+++ b/src/VCO.h
@@ -117,6 +117,7 @@ template <int oscType> struct VCO : public modules::XTModule
     modules::ModulationAssistant<VCO<oscType>, n_osc_params + 1, PITCH_CV, n_mod_inputs,
                                  OSC_MOD_INPUT>
         modAssist;
+    int wavetableCount{0};
 
     VCO() : XTModule(), halfbandIN(6, true)
     {
@@ -128,6 +129,8 @@ template <int oscType> struct VCO : public modules::XTModule
 
         memset(audioInBuffer, 0, BLOCK_SIZE_OS * sizeof(float));
         setupSurgeCommon(NUM_PARAMS, VCOConfig<oscType>::requiresWavetables());
+
+        wavetableCount = storage->wt_list.size();
 
         oscstorage = &(storage->getPatch().scene[0].osc[0]);
         oscstorage_display = &(storage->getPatch().scene[0].osc[1]);
@@ -346,6 +349,8 @@ template <int oscType> struct VCO : public modules::XTModule
 
     std::string getWavetableName()
     {
+        if (wavetableCount == 0)
+            return "ERROR: NO WAVETABLES";
         int idx = wavetableIndex;
         if (idx >= 0)
             return storage->wt_list[idx].name;
@@ -399,6 +404,9 @@ template <int oscType> struct VCO : public modules::XTModule
         bool reInitEveryOSC{false};
         if constexpr (VCOConfig<oscType>::requiresWavetables())
         {
+            if (wavetableCount == 0)
+                return;
+
             if (suspendForWT)
                 return;
 


### PR DESCRIPTION
When mis-installed so the wavetables aren't there, the oscillators should still not segv. Now they don't
(but they don't work of course)

Closes #535