### PR TITLE
Friday Fixes from Github Issues

### DIFF
--- a/src/VCF.cpp
+++ b/src/VCF.cpp
@@ -229,7 +229,7 @@ struct VCFSubtypeSelector : widgets::ParamJogSelector
 
         i += dir;
         if (i < 0)
-            i = sst::filters::fut_subcount[type];
+            i = sst::filters::fut_subcount[type] - 1;
         if (i >= sst::filters::fut_subcount[type])
             i = 0;
 

--- a/src/Waveshaper.h
+++ b/src/Waveshaper.h
@@ -100,8 +100,8 @@ struct Waveshaper : public modules::XTModule
         configParamNoRand<modules::DecibelParamQuantity>(OUT_GAIN, 0, 2, 1, "Gain");
         configParam<modules::MidiNoteParamQuantity<69>>(LOCUT, -60, 70, -60, "Low Cut");
         configParam<modules::MidiNoteParamQuantity<69>>(HICUT, -60, 70, 70, "High Cut");
-        configParam(LOCUT_ENABLED, 0, 1, 0);
-        configParam(HICUT_ENABLED, 0, 1, 0);
+        configParam<modules::OnOffParamQuantity>(LOCUT_ENABLED, 0, 1, 0, "Enable Low Cut");
+        configParam<modules::OnOffParamQuantity>(HICUT_ENABLED, 0, 1, 0, "Enable High Cut");
 
         configParam<WaveshaperTypeParamQuanity>(WSHP_TYPE, 0,
                                                 (int)sst::waveshapers::WaveshaperType::n_ws_types,

--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -574,6 +574,42 @@ struct DecibelParamQuantity : rack::engine::ParamQuantity
     }
 };
 
+
+struct OnOffParamQuantity : rack::engine::ParamQuantity
+{
+    std::string getDisplayValueString() override
+    {
+        auto v = getValue();
+        if (v < 0.5)
+            return "Off";
+
+        return "On";
+    }
+
+    void setDisplayValueString(std::string s) override
+    {
+        auto sl = s;
+        for (auto &c : sl)
+            c = std::tolower(c);
+
+        bool val = 0;
+        if (sl == "off" )
+        {
+            val = false;
+        }
+        else if (sl == "on")
+        {
+            val = true;
+        }
+        else
+        {
+            val = (std::atof(s.c_str()) > 0.5);
+        }
+        setValue(val);
+    }
+};
+
+
 template <typename M> struct DecibelModulatorParamQuantity : rack::ParamQuantity
 {
     inline M *xtm() { return static_cast<M *>(module); }

--- a/src/XTModuleWidget.cpp
+++ b/src/XTModuleWidget.cpp
@@ -80,7 +80,7 @@ void lightMenuFor(rack::Menu *p, XTModuleWidget *w)
 
     auto glob = xtm->isCoupledToGlobalStyle;
     auto clight = glob ? style::XTStyle::getGlobalLightColor() : xtm->localLightColor;
-    for (int ski = style::XTStyle::LightColor::ORANGE; ski <= style::XTStyle::LightColor::RED;
+    for (int ski = style::XTStyle::LightColor::ORANGE; ski <= style::XTStyle::LightColor::WHITE;
          ++ski)
     {
         auto sk = (style::XTStyle::LightColor)ski;
@@ -103,7 +103,7 @@ void modLightMenuFor(rack::Menu *p, XTModuleWidget *w)
 
     auto glob = xtm->isCoupledToGlobalStyle;
     auto clight = glob ? style::XTStyle::getGlobalModLightColor() : xtm->localModLightColor;
-    for (int ski = style::XTStyle::LightColor::ORANGE; ski <= style::XTStyle::LightColor::RED;
+    for (int ski = style::XTStyle::LightColor::ORANGE; ski <= style::XTStyle::LightColor::WHITE;
          ++ski)
     {
         auto sk = (style::XTStyle::LightColor)ski;

--- a/src/XTStyle.cpp
+++ b/src/XTStyle.cpp
@@ -60,7 +60,7 @@ void XTStyle::initialize()
             if (defj)
                 lightColId = json_integer_value(defj);
 
-            if (lightColId >= ORANGE && lightColId <= RED)
+            if (lightColId >= ORANGE && lightColId <= WHITE)
             {
                 setGlobalLightColor((LightColor)lightColId);
             }
@@ -76,7 +76,7 @@ void XTStyle::initialize()
             if (defj)
                 lightColId = json_integer_value(defj);
 
-            if (lightColId >= ORANGE && lightColId <= RED)
+            if (lightColId >= ORANGE && lightColId <= WHITE)
             {
                 setGlobalModLightColor((LightColor)lightColId);
             }
@@ -88,22 +88,6 @@ void XTStyle::initialize()
         json_decref(fd);
     }
 }
-
-// Font dictionary
-struct InternalFontMgr
-{
-    static std::map<std::string, int> fontMap;
-    static int get(NVGcontext *vg, std::string resName)
-    {
-        if (fontMap.find(resName) == fontMap.end())
-        {
-            std::string fontPath = rack::asset::plugin(pluginInstance, resName);
-
-            fontMap[resName] = nvgCreateFont(vg, resName.c_str(), fontPath.c_str());
-        }
-        return fontMap[resName];
-    }
-};
 
 static XTStyle::Style defaultGlobalStyle{XTStyle::MID};
 static XTStyle::LightColor defaultGlobalLightColor{XTStyle::ORANGE};
@@ -292,13 +276,14 @@ NVGcolor XTStyle::lightColorColor(sst::surgext_rack::style::XTStyle::LightColor 
         return nvgRGB(158, 130, 243);
     case PINK:
         return nvgRGB(255, 82, 163);
+    case WHITE:
+        return nvgRGB(250, 250, 250);
     case RED:
         return nvgRGB(240, 67, 67);
     }
 
     return nvgRGB(255, 0, 1);
 }
-std::map<std::string, int> InternalFontMgr::fontMap;
 
 std::unordered_set<StyleParticipant *> XTStyle::listeners;
 
@@ -334,6 +319,8 @@ std::string XTStyle::lightColorName(sst::surgext_rack::style::XTStyle::LightColo
         return "Purple";
     case PINK:
         return "Pink";
+    case WHITE:
+        return "White";
     case RED:
         return "Red";
     }
@@ -381,17 +368,15 @@ static const char *fontFaceBold()
 
 int XTStyle::fontId(NVGcontext *vg)
 {
-    static int fid{-1};
-    if (fid < 0)
-        fid = InternalFontMgr::get(vg, fontFace());
-    return fid;
+    auto fontPath = rack::asset::plugin(pluginInstance, fontFace());
+    auto font = APP->window->loadFont(fontPath);
+    return font->handle;
 }
 
 int XTStyle::fontIdBold(NVGcontext *vg)
 {
-    static int fid{-1};
-    if (fid < 0)
-        fid = InternalFontMgr::get(vg, fontFaceBold());
-    return fid;
+    auto fontPath = rack::asset::plugin(pluginInstance, fontFaceBold());
+    auto font = APP->window->loadFont(fontPath);
+    return font->handle;
 }
 } // namespace sst::surgext_rack::style

--- a/src/XTStyle.h
+++ b/src/XTStyle.h
@@ -51,7 +51,8 @@ struct XTStyle
         BLUE,
         PURPLE,
         PINK,
-        RED // must be last
+        RED,
+        WHITE // If you change this as last, change the ranges in XTMW and XGS.cpp
     };
     LightColor *activeModLight{nullptr}, *activeLight{nullptr};
 

--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -766,18 +766,25 @@ struct ActivateKnobSwitch : rack::app::Switch, style::StyleParticipant
     }
 
     bool hovered{false};
-    void onHover(const HoverEvent &e) override { e.consume(this); }
+    void onHover(const HoverEvent &e) override {
+        e.consume(this);
+        rack::app::Switch::onHover(e);
+    }
     void onEnter(const EnterEvent &e) override
     {
         hovered = true;
         bdw->dirty = true;
         e.consume(this);
+
+        rack::app::Switch::onEnter(e);
     }
     void onLeave(const LeaveEvent &e) override
     {
         hovered = false;
         bdw->dirty = true;
         e.consume(this);
+
+        rack::app::Switch::onLeave(e);
     }
 
     void setupExtendedPath(NVGcontext *vg)
@@ -910,18 +917,23 @@ template <typename T> struct GlowOverlayHoverButton : T, style::StyleParticipant
     }
 
     bool hovered{false};
-    void onHover(const typename T::HoverEvent &e) override { e.consume(this); }
+    void onHover(const typename T::HoverEvent &e) override {
+        e.consume(this);
+        T::onHover(e);
+    }
     void onEnter(const typename T::EnterEvent &e) override
     {
         hovered = true;
         bw->dirty = true;
         e.consume(this);
+        T::onEnter(e);
     }
     void onLeave(const typename T::LeaveEvent &e) override
     {
         hovered = false;
         bw->dirty = true;
         e.consume(this);
+        T::onLeave(e);
     }
 
     void drawButtonGlow(NVGcontext *vg)

--- a/src/fxconfig/Chorus.h
+++ b/src/fxconfig/Chorus.h
@@ -76,8 +76,10 @@ template <> FXConfig<fxt_chorus4>::layout_t FXConfig<fxt_chorus4>::getLayout()
 template <> void FXConfig<fxt_chorus4>::configSpecificParams(FX<fxt_chorus4> *m)
 {
     typedef FX<fxt_chorus4> fx_t;
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1, "Enable LowCut");
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 1, "Enable HiCut");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1,
+                                                "Enable Low Cut");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 1,
+                                                "Enable High Cut");
 }
 
 template <> void FXConfig<fxt_chorus4>::processSpecificParams(FX<fxt_chorus4> *m)

--- a/src/fxconfig/Chow.h
+++ b/src/fxconfig/Chow.h
@@ -53,7 +53,7 @@ template <> FXConfig<fxt_chow>::layout_t FXConfig<fxt_chow>::getLayout()
 template <> void FXConfig<fxt_chow>::configSpecificParams(FX<fxt_chow> *m)
 {
     typedef FX<fxt_chow> fx_t;
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 0, "Flip");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 0, "Flip it Good");
 }
 
 /*

--- a/src/fxconfig/Combulator.h
+++ b/src/fxconfig/Combulator.h
@@ -66,7 +66,8 @@ template <> FXConfig<fxt_combulator>::layout_t FXConfig<fxt_combulator>::getLayo
 template <> void FXConfig<fxt_combulator>::configSpecificParams(FX<fxt_combulator> *m)
 {
     typedef FX<fxt_combulator> fx_t;
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1, "Enable Tone Filter");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1,
+                                                "Enable Tone Filter");
 }
 
 template <> void FXConfig<fxt_combulator>::processSpecificParams(FX<fxt_combulator> *m)

--- a/src/fxconfig/Distortion.h
+++ b/src/fxconfig/Distortion.h
@@ -69,8 +69,10 @@ template <> FXConfig<fxt_distortion>::layout_t FXConfig<fxt_distortion>::getLayo
 template <> void FXConfig<fxt_distortion>::configSpecificParams(FX<fxt_distortion> *m)
 {
     typedef FX<fxt_distortion> fx_t;
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1, "Enable Pre Hi Cut");
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 1, "Enable Post Hi Cut");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1,
+                                                "Enable Pre High Cut");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 1,
+                                                "Enable Post High Cut");
 }
 
 template <> void FXConfig<fxt_distortion>::processSpecificParams(FX<fxt_distortion> *m)

--- a/src/fxconfig/FrequencyShifter.h
+++ b/src/fxconfig/FrequencyShifter.h
@@ -53,7 +53,8 @@ template <> constexpr bool FXConfig<fxt_freqshift>::usesClock() { return true; }
 template <> void FXConfig<fxt_freqshift>::configSpecificParams(FX<fxt_freqshift> *m)
 {
     typedef FX<fxt_freqshift> fx_t;
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 0, "Extend Frequency");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 0,
+                                                "Extend Frequency");
 
     // Limit max delay to 1second by setting the upper bound to '0' in 2^x land
     auto &p = m->fxstorage->p[FrequencyShifterEffect::freq_delay];

--- a/src/fxconfig/Phaser.h
+++ b/src/fxconfig/Phaser.h
@@ -71,7 +71,8 @@ template <> FXConfig<fxt_phaser>::layout_t FXConfig<fxt_phaser>::getLayout()
 template <> void FXConfig<fxt_phaser>::configSpecificParams(FX<fxt_phaser> *m)
 {
     typedef FX<fxt_phaser> fx_t;
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1, "Enable Tone");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1,
+                                                "Enable Tone Filter");
 }
 
 template <> void FXConfig<fxt_phaser>::processSpecificParams(FX<fxt_phaser> *m)

--- a/src/fxconfig/Resonator.h
+++ b/src/fxconfig/Resonator.h
@@ -71,6 +71,17 @@ template <> FXConfig<fxt_resonator>::layout_t FXConfig<fxt_resonator>::getLayout
 
     // clang-format on
 }
+
+template <> void FXConfig<fxt_resonator>::configSpecificParams(FX<fxt_resonator> *m)
+{
+    typedef FX<fxt_resonator> fx_t;
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0 + 0, 0, 1, 0,
+                                                "Extend Band 1 Frequency");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 0,
+                                                "Extend Band 2 Frequency");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0 + 2, 0, 1, 0,
+                                                "Extend Band 3 Frequency");
+}
 template <> void FXConfig<fxt_resonator>::processSpecificParams(FX<fxt_resonator> *m)
 {
     typedef FX<fxt_resonator> fx_t;

--- a/src/fxconfig/Reverb1.h
+++ b/src/fxconfig/Reverb1.h
@@ -30,7 +30,7 @@ template <> constexpr int FXConfig<fxt_reverb>::specificParamCount() { return 2;
 template <> FXConfig<fxt_reverb>::layout_t FXConfig<fxt_reverb>::getLayout()
 {
     const auto col = FXLayoutHelper::standardColumns_MM();
-    
+
     const auto row3 = FXLayoutHelper::rowStart_MM;
     const auto row2 = row3 - FXLayoutHelper::labeledGap_MM;
     const auto row1 = row2 - FXLayoutHelper::knobGap16_MM;
@@ -67,8 +67,10 @@ template <> FXConfig<fxt_reverb>::layout_t FXConfig<fxt_reverb>::getLayout()
 template <> void FXConfig<fxt_reverb>::configSpecificParams(FX<fxt_reverb> *m)
 {
     typedef FX<fxt_reverb> fx_t;
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1, "Enable LowCut");
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 1, "Enable HiCut");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1,
+                                                "Enable Low Cut");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 1,
+                                                "Enable High Cut");
 }
 
 template <> void FXConfig<fxt_reverb>::processSpecificParams(FX<fxt_reverb> *m)

--- a/src/fxconfig/RingModulator.h
+++ b/src/fxconfig/RingModulator.h
@@ -31,7 +31,7 @@ template <> constexpr int FXConfig<fxt_ringmod>::specificParamCount() { return 2
 template <> FXConfig<fxt_ringmod>::layout_t FXConfig<fxt_ringmod>::getLayout()
 {
     const auto col = FXLayoutHelper::standardColumns_MM();
-    
+
     const auto row3 = FXLayoutHelper::rowStart_MM;
     const auto row2 = row3 - FXLayoutHelper::labeledGap_MM;
     const auto row1 = row2 - FXLayoutHelper::labeledGap_MM - (14 - 9) * 0.5f;
@@ -71,8 +71,10 @@ template <> FXConfig<fxt_ringmod>::layout_t FXConfig<fxt_ringmod>::getLayout()
 template <> void FXConfig<fxt_ringmod>::configSpecificParams(FX<fxt_ringmod> *m)
 {
     typedef FX<fxt_ringmod> fx_t;
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1, "Enable Lo Cut");
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 1, "Enable Hi Cut");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1,
+                                                "Enable Low Cut");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 1,
+                                                "Enable High Cut");
 }
 
 template <> void FXConfig<fxt_ringmod>::processSpecificParams(FX<fxt_ringmod> *m)

--- a/src/fxconfig/SpringReverb.h
+++ b/src/fxconfig/SpringReverb.h
@@ -62,7 +62,8 @@ template <> FXConfig<fxt_spring_reverb>::layout_t FXConfig<fxt_spring_reverb>::g
 template <> void FXConfig<fxt_spring_reverb>::configSpecificParams(FX<fxt_spring_reverb> *m)
 {
     typedef FX<fxt_spring_reverb> fx_t;
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 0, "Interrupting Cow");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 0,
+                                                "Interrupting Cow");
 }
 
 /*

--- a/src/fxconfig/TreeMonster.h
+++ b/src/fxconfig/TreeMonster.h
@@ -31,7 +31,7 @@ template <> FXConfig<fxt_treemonster>::layout_t FXConfig<fxt_treemonster>::getLa
     const auto row3 = FXLayoutHelper::rowStart_MM;
     const auto row2 = row3 - FXLayoutHelper::labeledGap_MM;
     const auto row1 = row2 - FXLayoutHelper::knobGap16_MM;
-    
+
     const auto col15 = (col[0] + col[1]) * 0.5f;
     const auto col25 = (col[2] + col[3]) * 0.5f;
 
@@ -66,8 +66,10 @@ template <> FXConfig<fxt_treemonster>::layout_t FXConfig<fxt_treemonster>::getLa
 template <> void FXConfig<fxt_treemonster>::configSpecificParams(FX<fxt_treemonster> *m)
 {
     typedef FX<fxt_treemonster> fx_t;
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1, "Enable Lo Cut");
-    m->configParam(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 1, "Enable Post Hi Cut");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0, 0, 1, 1,
+                                                "Enable Low Cut");
+    m->configParam<modules::OnOffParamQuantity>(fx_t::FX_SPECIFIC_PARAM_0 + 1, 0, 1, 1,
+                                                "Enable High Cut");
 
     // Default TM to polyphonic
     m->polyphonicMode = true;

--- a/src/vcoconfig/SHNoise.h
+++ b/src/vcoconfig/SHNoise.h
@@ -44,6 +44,19 @@ template <> VCOConfig<ot_shnoise>::layout_t VCOConfig<ot_shnoise>::getLayout()
     };
 }
 
+template <> inline void VCOConfig<ot_shnoise>::configureVCOSpecificParameters(VCO<ot_shnoise> *m)
+{
+    m->configParam<modules::OnOffParamQuantity>(VCO<ot_shnoise>::ARBITRARY_SWITCH_0 + 0, 0, 1, 0,
+                                                "Enable Low Cut");
+    m->configParam<modules::OnOffParamQuantity>(VCO<ot_shnoise>::ARBITRARY_SWITCH_0 + 1, 0, 1, 0,
+                                                "Enable High Cut");
+
+    for (int i = 2; i < VCO<ot_shnoise>::n_arbitrary_switches; ++i)
+    {
+        m->configParam(VCO<ot_shnoise>::ARBITRARY_SWITCH_0 + i, 0, 1, 0, "Unused");
+    }
+}
+
 template <> void VCOConfig<ot_shnoise>::processVCOSpecificParameters(VCO<ot_shnoise> *m)
 {
     auto l0 = (bool)(m->params[VCO<ot_shnoise>::ARBITRARY_SWITCH_0 + 0].getValue() > 0.5);

--- a/src/vcoconfig/Sine.h
+++ b/src/vcoconfig/Sine.h
@@ -43,6 +43,18 @@ template <> VCOConfig<ot_sine>::layout_t VCOConfig<ot_sine>::getLayout()
 
 template <> int VCOConfig<ot_sine>::rightMenuParamId() { return 0; }
 
+template <> inline void VCOConfig<ot_sine>::configureVCOSpecificParameters(VCO<ot_sine> *m)
+{
+    m->configParam<modules::OnOffParamQuantity>(VCO<ot_sine>::ARBITRARY_SWITCH_0 + 0, 0, 1, 0,
+                                                "Enable Low Cut");
+    m->configParam<modules::OnOffParamQuantity>(VCO<ot_sine>::ARBITRARY_SWITCH_0 + 1, 0, 1, 0,
+                                                "Enable High Cut");
+
+    for (int i = 2; i < VCO<ot_sine>::n_arbitrary_switches; ++i)
+    {
+        m->configParam(VCO<ot_sine>::ARBITRARY_SWITCH_0 + i, 0, 1, 0, "Unused");
+    }
+}
 template <> void VCOConfig<ot_sine>::oscillatorSpecificSetup(VCO<ot_sine> *m)
 {
     for (auto s : {m->oscstorage, m->oscstorage_display})

--- a/src/vcoconfig/Twist.h
+++ b/src/vcoconfig/Twist.h
@@ -209,6 +209,16 @@ template <> VCOConfig<ot_twist>::layout_t VCOConfig<ot_twist>::getLayout()
 template <> int VCOConfig<ot_twist>::rightMenuParamId() { return 0; }
 template <> std::string VCOConfig<ot_twist>::retriggerLabel() { return "TRIG"; }
 
+template <> inline void VCOConfig<ot_twist>::configureVCOSpecificParameters(VCO<ot_twist> *m)
+{
+    m->configParam<modules::OnOffParamQuantity>(VCO<ot_twist>::ARBITRARY_SWITCH_0 + 0, 0, 1, 0,
+                                                "Enable LPG on Trigger");
+
+    for (int i = 1; i < VCO<ot_twist>::n_arbitrary_switches; ++i)
+    {
+        m->configParam(VCO<ot_twist>::ARBITRARY_SWITCH_0 + i, 0, 1, 0, "Unused");
+    }
+}
 template <> void VCOConfig<ot_twist>::processVCOSpecificParameters(VCO<ot_twist> *m)
 {
     auto l0 = (bool)(m->params[VCO<ot_twist>::ARBITRARY_SWITCH_0 + 0].getValue() > 0.5);

--- a/src/vcoconfig/Window.h
+++ b/src/vcoconfig/Window.h
@@ -54,6 +54,19 @@ template <> void VCOConfig<ot_window>::oscillatorSpecificSetup(VCO<ot_window> *m
     }
 }
 
+template <> inline void VCOConfig<ot_window>::configureVCOSpecificParameters(VCO<ot_window> *m)
+{
+    m->configParam<modules::OnOffParamQuantity>(VCO<ot_window>::ARBITRARY_SWITCH_0 + 0, 0, 1, 0,
+                                                "Enable Low Cut");
+    m->configParam<modules::OnOffParamQuantity>(VCO<ot_window>::ARBITRARY_SWITCH_0 + 1, 0, 1, 0,
+                                                "Enable High Cut");
+
+    for (int i = 2; i < VCO<ot_window>::n_arbitrary_switches; ++i)
+    {
+        m->configParam(VCO<ot_window>::ARBITRARY_SWITCH_0 + i, 0, 1, 0, "Unused");
+    }
+}
+
 template <> void VCOConfig<ot_window>::processVCOSpecificParameters(VCO<ot_window> *m)
 {
     auto l0 = (bool)(m->params[VCO<ot_window>::ARBITRARY_SWITCH_0 + 0].getValue() > 0.5);


### PR DESCRIPTION
- Negative-direction wrap on VCF subtype jog works. Closes #546
- Add a WHITE color LED. Closes #547

Then:
- Activate tooltips on the power button and glow non-mod button.
- Make sure all tooltip labels for enable etc... are consistent
- Add correct labels to several modules missing them
- Add an On/Off Param Quantity type which displays On/Off rather than 1/0 and handles appropriate type in.

Above set closes #543