### PR TITLE
Separate the colors a bit more

### DIFF
--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -193,8 +193,10 @@ struct XTModule : public rack::Module
         json_object_set_new(rootJ, "buildInfo", json_string(getBuildInfo().c_str()));
         json_object_set_new(rootJ, "isCoupledToGlobalStyle", json_boolean(isCoupledToGlobalStyle));
         json_object_set_new(rootJ, "localStyle", json_integer(localStyle));
-        json_object_set_new(rootJ, "localLightColor", json_integer(localLightColor));
-        json_object_set_new(rootJ, "localModLightColor", json_integer(localModLightColor));
+        json_object_set_new(rootJ, "localDisplayRegionColor", json_integer(localDisplayRegionColor));
+        json_object_set_new(rootJ, "localModulationColor", json_integer(localModulationColor));
+        json_object_set_new(rootJ, "localControlValueColor", json_integer(localControlValueColor));
+        json_object_set_new(rootJ, "localPowerButtonColor", json_integer(localPowerButtonColor));
         return rootJ;
     }
 
@@ -207,12 +209,18 @@ struct XTModule : public rack::Module
         auto ls = json_object_get(commonJ, "localStyle");
         if (ls)
             localStyle = (style::XTStyle::Style)json_integer_value(ls);
-        auto ll = json_object_get(commonJ, "localLightColor");
+        auto ll = json_object_get(commonJ, "localDisplayRegionColor");
         if (ll)
-            localLightColor = (style::XTStyle::LightColor)json_integer_value(ll);
-        auto lm = json_object_get(commonJ, "localModLightColor");
+            localDisplayRegionColor = (style::XTStyle::LightColor)json_integer_value(ll);
+        auto lm = json_object_get(commonJ, "localModulationColor");
         if (lm)
-            localModLightColor = (style::XTStyle::LightColor)json_integer_value(lm);
+            localModulationColor = (style::XTStyle::LightColor)json_integer_value(lm);
+        lm = json_object_get(commonJ, "localControlValueColor");
+        if (lm)
+            localControlValueColor = (style::XTStyle::LightColor)json_integer_value(lm);
+        lm = json_object_get(commonJ, "localPowerButtonColor");
+        if (lm)
+            localPowerButtonColor = (style::XTStyle::LightColor)json_integer_value(lm);
     }
 
     virtual json_t *makeModuleSpecificJson() { return nullptr; }
@@ -253,8 +261,10 @@ struct XTModule : public rack::Module
 
     bool isCoupledToGlobalStyle{true};
     style::XTStyle::Style localStyle{style::XTStyle::LIGHT};
-    style::XTStyle::LightColor localLightColor{style::XTStyle::ORANGE},
-        localModLightColor{style::XTStyle::BLUE};
+    style::XTStyle::LightColor localDisplayRegionColor{style::XTStyle::ORANGE},
+        localModulationColor{style::XTStyle::BLUE},
+        localControlValueColor{style::XTStyle::ORANGE},
+        localPowerButtonColor{style::XTStyle::GREEN};
 };
 
 struct SurgeParameterParamQuantity : public rack::engine::ParamQuantity

--- a/src/XTStyle.h
+++ b/src/XTStyle.h
@@ -54,13 +54,24 @@ struct XTStyle
         RED,
         WHITE // If you change this as last, change the ranges in XTMW and XGS.cpp
     };
-    LightColor *activeModLight{nullptr}, *activeLight{nullptr};
+    LightColor *activeModulationColor{nullptr}, *activeDisplayRegionColor{nullptr},
+        *activeControlValueColor{nullptr}, *activePowerButtonColor{nullptr};
+
+    static void setGlobalDisplayRegionColor(LightColor c);
+    static LightColor getGlobalDisplayRegionColor();
+
+    static void setGlobalModulationColor(LightColor c);
+    static LightColor getGlobalModulationColor();
+
+    static void setGlobalControlValueColor(LightColor c);
+    static LightColor getGlobalControlValueColor();
+    static bool getControlValueColorDistinct();
+    static void setControlValueColorDistinct(bool b);
+
+    static void setGlobalPowerButtonColor(LightColor c);
+    static LightColor getGlobalPowerButtonColor();
 
     static std::string lightColorName(LightColor c);
-    static void setGlobalLightColor(LightColor c);
-    static LightColor getGlobalLightColor();
-    static void setGlobalModLightColor(LightColor c);
-    static LightColor getGlobalModLightColor();
     static NVGcolor lightColorColor(LightColor c);
 
     enum Colors
@@ -71,11 +82,16 @@ struct XTStyle
         KNOB_MOD_MARK,
         KNOB_RING_VALUE,
 
+        PANEL_RULER,
+
         PLOT_CURVE,
         PLOT_MARKS,
 
         MOD_BUTTON_LIGHT_ON,
         MOD_BUTTON_LIGHT_OFF,
+
+        POWER_BUTTON_LIGHT_ON,
+        POWER_BUTTON_LIGHT_OFF,
 
         TEXT_LABEL,
         TEXT_LABEL_OUTPUT,
@@ -114,6 +130,7 @@ struct StyleParticipant
 
     void attachToGlobalStyle();
     void attachTo(style::XTStyle::Style *, style::XTStyle::LightColor *,
+                  style::XTStyle::LightColor *, style::XTStyle::LightColor *,
                   style::XTStyle::LightColor *);
 
     std::shared_ptr<XTStyle> stylePtr{nullptr};

--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -725,7 +725,7 @@ struct GroupLabel : rack::widget::TransparentWidget, style::StyleParticipant
         nvgArcTo(vg, x0, yline, x0 + 2, yline, 2);
         nvgLineTo(vg, textBox[0] - 2, yline);
         nvgStrokeWidth(vg, 1.2);
-        nvgStrokeColor(vg, style()->getColor(style::XTStyle::KNOB_RING));
+        nvgStrokeColor(vg, style()->getColor(style::XTStyle::PANEL_RULER));
         nvgStroke(vg);
 
         nvgBeginPath(vg);
@@ -734,7 +734,7 @@ struct GroupLabel : rack::widget::TransparentWidget, style::StyleParticipant
         nvgArcTo(vg, x1, yline, x1 - 2, yline, 2);
         nvgLineTo(vg, textBox[2] + 2, yline);
         nvgStrokeWidth(vg, 1.2);
-        nvgStrokeColor(vg, style()->getColor(style::XTStyle::KNOB_RING));
+        nvgStrokeColor(vg, style()->getColor(style::XTStyle::PANEL_RULER));
         nvgStroke(vg);
     }
 
@@ -803,7 +803,7 @@ struct ActivateKnobSwitch : rack::app::Switch, style::StyleParticipant
 
     void drawBackground(NVGcontext *vg)
     {
-        auto col = style()->getColor(style::XTStyle::MOD_BUTTON_LIGHT_OFF);
+        auto col = style()->getColor(style::XTStyle::POWER_BUTTON_LIGHT_OFF);
         if (hovered)
         {
             col.r *= 1.2;
@@ -813,7 +813,7 @@ struct ActivateKnobSwitch : rack::app::Switch, style::StyleParticipant
         if (type == POWER)
         {
             nvgBeginPath(vg);
-            nvgStrokeColor(vg, style()->getColor(style::XTStyle::KNOB_RING));
+            nvgStrokeColor(vg, style()->getColor(style::XTStyle::PANEL_RULER));
             nvgFillColor(vg, col);
             nvgEllipse(vg, box.size.x * 0.5, box.size.y * 0.5, radius, radius);
             nvgFill(vg);
@@ -823,7 +823,7 @@ struct ActivateKnobSwitch : rack::app::Switch, style::StyleParticipant
         if (type == ABSOLUTE)
         {
             nvgBeginPath(vg);
-            nvgStrokeColor(vg, style()->getColor(style::XTStyle::KNOB_RING));
+            nvgStrokeColor(vg, style()->getColor(style::XTStyle::PANEL_RULER));
             nvgFillColor(vg, col);
             nvgFontFaceId(vg, style()->fontIdBold(vg));
             nvgFontSize(vg, layout::LayoutConstants::labelSize_pt * 96 / 72);
@@ -836,7 +836,7 @@ struct ActivateKnobSwitch : rack::app::Switch, style::StyleParticipant
         if (type == EXTENDED)
         {
             setupExtendedPath(vg);
-            nvgStrokeColor(vg, style()->getColor(style::XTStyle::KNOB_RING));
+            nvgStrokeColor(vg, style()->getColor(style::XTStyle::PANEL_RULER));
             nvgFillColor(vg, col);
             nvgStrokeWidth(vg, 1.2);
             nvgStroke(vg);
@@ -855,14 +855,14 @@ struct ActivateKnobSwitch : rack::app::Switch, style::StyleParticipant
         if (type == POWER)
         {
             nvgBeginPath(vg);
-            nvgFillColor(vg, style()->getColor(style::XTStyle::MOD_BUTTON_LIGHT_ON));
+            nvgFillColor(vg, style()->getColor(style::XTStyle::POWER_BUTTON_LIGHT_ON));
             nvgEllipse(vg, box.size.x * 0.5, box.size.y * 0.5, radius * 0.9, radius * 0.9);
             nvgFill(vg);
         }
         if (type == ABSOLUTE)
         {
             nvgBeginPath(vg);
-            nvgFillColor(vg, style()->getColor(style::XTStyle::MOD_BUTTON_LIGHT_ON));
+            nvgFillColor(vg, style()->getColor(style::XTStyle::POWER_BUTTON_LIGHT_ON));
             nvgFontFaceId(vg, style()->fontIdBold(vg));
             nvgFontSize(vg, layout::LayoutConstants::labelSize_pt * 96 / 72);
             nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
@@ -872,7 +872,7 @@ struct ActivateKnobSwitch : rack::app::Switch, style::StyleParticipant
         if (type == EXTENDED)
         {
             setupExtendedPath(vg);
-            nvgFillColor(vg, style()->getColor(style::XTStyle::MOD_BUTTON_LIGHT_ON));
+            nvgFillColor(vg, style()->getColor(style::XTStyle::POWER_BUTTON_LIGHT_ON));
             nvgFill(vg);
         }
     }
@@ -1564,7 +1564,7 @@ struct ThereAreFourLights : rack::app::SliderKnob, style::StyleParticipant
         {
             auto y0 = i * (ringpx + padpx);
             nvgBeginPath(vg);
-            nvgStrokeColor(vg, style()->getColor(style::XTStyle::KNOB_RING));
+            nvgStrokeColor(vg, style()->getColor(style::XTStyle::PANEL_RULER));
             nvgFillColor(vg, style()->getColor(style::XTStyle::MOD_BUTTON_LIGHT_OFF));
             nvgEllipse(vg, box.size.x * 0.5, y0 + ringpx * 0.5, ringpx * 0.5, ringpx * 0.5);
             nvgFill(vg);
@@ -1583,7 +1583,7 @@ struct ThereAreFourLights : rack::app::SliderKnob, style::StyleParticipant
                   Parameter::intUnscaledFromFloat(getParamQuantity()->getValue(), nLights - 1);
         nvgBeginPath(vg);
         auto y0 = pq * (ringpx + padpx);
-        nvgStrokeColor(vg, style()->getColor(style::XTStyle::KNOB_RING));
+        nvgStrokeColor(vg, style()->getColor(style::XTStyle::PANEL_RULER));
         nvgFillColor(vg, style()->getColor(style::XTStyle::KNOB_RING_VALUE));
         nvgEllipse(vg, box.size.x * 0.5, y0 + ringpx * 0.5, ringpx * 0.5, ringpx * 0.5);
         nvgFill(vg);


### PR DESCRIPTION
1. Four colors (display area, knob rings, power buttons, modulations)
2. All separately addressible, but also knob rings can attach to display by default
3. White rings on light background have darker ring

Closes #551
Closes #554