### PR TITLE
Saturday fun and tweaks

### DIFF
--- a/src/LFO.cpp
+++ b/src/LFO.cpp
@@ -284,6 +284,34 @@ struct LFOStepWidget : rack::Widget, style::StyleParticipant
             bdw->dirty = true;
             bdwLight->dirty = true;
         }
+
+        rack::Vec buttonPos;
+        void onButton(const ButtonEvent &e) override
+        {
+            if (e.action == GLFW_PRESS)
+                buttonPos = e.pos;
+
+            if (e.action == GLFW_RELEASE)
+            {
+                auto diff = buttonPos - e.pos;
+                if (diff.norm() < 0.05)
+                {
+                    // auto e = cramY * box.size.y * v + padY;
+                    // e - padY = cY * bsy * v
+                    // v = ( e- padY)/(cY * bsy);
+                    auto val = (buttonPos.y - padY) / (cramY * box.size.y);
+                    if (uni)
+                        val = 1 - val;
+                    else
+                        val = (1 - val) * 2 - 1;
+                    if (getParamQuantity())
+                        getParamQuantity()->setValue(val);
+                }
+                buttonPos = rack::Vec(-1, -1);
+            }
+
+            SliderKnob::onButton(e);
+        }
     };
 
     struct TriggerSwitch : rack::app::Switch, style::StyleParticipant

--- a/src/VCO.cpp
+++ b/src/VCO.cpp
@@ -251,8 +251,12 @@ template <int oscType> struct WavetableSelector : widgets::PresetJogSelector
                                             [this]() { module->storage->refresh_wtlist(); }));
 
         menu->addChild(rack::createMenuItem("Load Wavetable File", "", [this]() {
-            auto filters = osdialog_filters_parse("Wavetables:wav,.wt");
+#if MAC
+            osdialog_filters* filters{nullptr};
+#else
+            auto filters = osdialog_filters_parse("Wavetables:wav,.WAV,.Wav,.wt,.WT,.Wt");
             DEFER({ osdialog_filters_free(filters); });
+#endif
             char *openF = osdialog_file(OSDIALOG_OPEN, nullptr, nullptr, filters);
             if (openF)
             {

--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -190,6 +190,8 @@ struct XTModule : public rack::Module
     json_t *makeCommonDataJson()
     {
         json_t *rootJ = json_object();
+        // For future use
+        json_object_set_new(rootJ, "streamingVersion", json_integer(1));
         json_object_set_new(rootJ, "buildInfo", json_string(getBuildInfo().c_str()));
         json_object_set_new(rootJ, "isCoupledToGlobalStyle", json_boolean(isCoupledToGlobalStyle));
         json_object_set_new(rootJ, "localStyle", json_integer(localStyle));

--- a/src/XTStyle.cpp
+++ b/src/XTStyle.cpp
@@ -296,12 +296,7 @@ const NVGcolor XTStyle::getColor(sst::surgext_rack::style::XTStyle::Colors c)
         case MID:
             return nvgRGB(40, 40, 40);
         case LIGHT:
-        {
-            auto lc = *activeDisplayRegionColor;
-            if (lc == WHITE && c == KNOB_RING)
-                return nvgRGB(0x33, 0x33, 0x33);
             return nvgRGB(194, 194, 194);
-        }
         }
     }
 
@@ -360,10 +355,16 @@ const NVGcolor XTStyle::getColor(sst::surgext_rack::style::XTStyle::Colors c)
 
     case KNOB_RING_VALUE:
     {
+        auto col = *activeDisplayRegionColor;
         if (getControlValueColorDistinct())
-            return lightColorColor(*activeControlValueColor);
-        else
-            return lightColorColor(*activeDisplayRegionColor);
+            col = *activeControlValueColor;
+        if (col == WHITE && *activeStyle == LIGHT)
+        {
+            // Special case - white ring on light background
+            return nvgRGB(0x33, 0x33, 0x33);
+        }
+
+        return lightColorColor(col);
     }
     case PLOT_CURVE:
     case PLOT_CONTROL_TEXT:

--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -852,6 +852,24 @@ struct ActivateKnobSwitch : rack::app::Switch, style::StyleParticipant
         if (q < 0.5)
             return;
 
+        const float halo = rack::settings::haloBrightness;
+
+        if (halo > 0.f)
+        {
+            auto dr = 1.6f;
+            nvgBeginPath(vg);
+            nvgEllipse(vg, box.size.x * 0.5, box.size.y * 0.5, radius * dr, radius * dr);
+
+            NVGcolor icol =
+                rack::color::mult(style()->getColor(style::XTStyle::POWER_BUTTON_LIGHT_ON), halo);
+            NVGcolor ocol = nvgRGBA(0, 0, 0, 0);
+            NVGpaint paint = nvgRadialGradient(vg, box.size.x * 0.5, box.size.y * 0.5, radius, radius*dr, icol, ocol);
+            nvgFillPaint(vg, paint);
+            nvgFill(vg);
+
+            drawBackground(vg);
+        }
+
         if (type == POWER)
         {
             nvgBeginPath(vg);
@@ -882,6 +900,20 @@ struct ActivateKnobSwitch : rack::app::Switch, style::StyleParticipant
         bdw->dirty = true;
         bdwLight->dirty = true;
         Widget::onChange(e);
+    }
+
+
+    float phalo{0.f};
+    void step() override
+    {
+        const float halo = rack::settings::haloBrightness;
+        if (phalo != halo)
+        {
+            phalo = halo;
+            bdw->dirty = true;
+            bdwLight->dirty = true;
+        }
+        Switch::step();
     }
     void onStyleChanged() override {}
 };
@@ -982,6 +1014,19 @@ template <typename T> struct GlowOverlayHoverButton : T, style::StyleParticipant
                        light_pixelRadius);
             nvgFill(vg);
         }
+    }
+
+    float phalo{0.f};
+    void step() override
+    {
+        const float halo = rack::settings::haloBrightness;
+        if (phalo != halo)
+        {
+            phalo = halo;
+            bw->dirty = true;
+            bwGlow->dirty = true;
+        }
+        T::step();
     }
 
     void setState(bool b)


### PR DESCRIPTION
- LFO click-to-set on the slider. Addresses #559
- Correctly deal with WHITE knob ring in LIGHT skin, after I finally understood what steve meant!
- No osfilter on mac; case multiple for win/lin. Addresses #552
- Add a bloom to small LEDs. Closes #548
- Put a streaming version of 1 in, just for the future