### PR TITLE
A few of the initial comments from Lars

### DIFF
--- a/src/VCO.cpp
+++ b/src/VCO.cpp
@@ -104,6 +104,12 @@ template <int oscType> struct VCOWidget : public widgets::XTModuleWidget
             driftSlider->quantity = module->paramQuantities[M::DRIFT];
             driftSlider->box.size.x = 125;
             menu->addChild(driftSlider);
+
+            auto attenSlider = new rack::ui::Slider;
+            attenSlider->quantity = module->paramQuantities[M::FIXED_ATTENUATION];
+            attenSlider->box.size.x = 125;
+            menu->addChild(attenSlider);
+
             menu->addChild(rack::createSubmenuItem("Halfband Filter", "",
                                                    [this,m](auto *x) { downsampleMenu(x,m);}));
 
@@ -991,6 +997,9 @@ VCOWidget<oscType>::VCOWidget(VCOWidget<oscType>::M *module) : XTModuleWidget()
                                                            rack::Vec(31, underPlotH), "UNI", module,
                                                            M::OSC_CTRL_PARAM_0 + 6);
         addChild(oct);
+        oct->minScale = 1;
+        oct->maxScale = 16;
+        oct->maxVal = 9;
         underX += 32 + 2;
     }
 

--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -1190,6 +1190,44 @@ struct LabeledPlotAreaControl : public rack::app::Knob, style::StyleParticipant
         bdw->dirty = true;
         Widget::onChange(e);
     }
+
+    bool parameterMenuOnClick{true};
+    int minScale{0}, maxScale{0}, maxVal{0};
+    void onAction(const ActionEvent &e) override {
+        if (parameterMenuOnClick && getParamQuantity())
+        {
+            auto pq = getParamQuantity();
+            if (pq->snapEnabled)
+            {
+                auto men = rack::createMenu();
+                men->addChild(rack::createMenuLabel(pq->getLabel()));
+                auto v = (int)std::round(pq->getValue());
+                for (int i=pq->getMaxValue(); i>=pq->getMinValue(); --i)
+                {
+                    men->addChild(rack::createMenuItem(std::to_string(i),
+                                                       CHECKMARK(i == v),
+                                                       [pq,i]() {pq->setValue(i);}));
+                }
+            }
+            else if (minScale != maxScale)
+            {
+                auto men = rack::createMenu();
+                men->addChild(rack::createMenuLabel(pq->getLabel()));
+
+                auto v = Parameter::intUnscaledFromFloat(pq->getValue(),
+                                                         maxScale,
+                                                         minScale);
+                for (int i=maxVal; i>=minScale; --i)
+                {
+                    men->addChild(rack::createMenuItem(std::to_string(i),
+                                                       CHECKMARK(i == v),
+                                                       [this,pq,i]() {pq->setValue(Parameter::intScaledToFloat(i, maxScale, minScale));}));
+
+                }
+            }
+        }
+        Knob::onAction(e);
+    }
 };
 
 struct PlotAreaSwitch : public rack::app::Switch, style::StyleParticipant


### PR DESCRIPTION
- Click unison etc.. and get a menu. Closes #568
- Output attenuator in menu. Closes #569
- Fix a problem where twist wouldn't recover from turning the LPG back off.
- Twist turns on LPG automatically when you connect a trigger input. Closes #571