### PR TITLE
Change modulation polyphony when mismatched

### DIFF
--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -740,7 +740,7 @@ struct ModulationAssistant
             if (connected[i])
             {
                 auto ch = m->inputs[i + input0].getChannels();
-                broadcast[i] = ch != chans;
+                broadcast[i] = ch == 1 && chans != 1;
             }
             else
             {


### PR DESCRIPTION
If your module has polyphony N and your modulator M and M != N we used to always use channel 1. This made sense when M == 1 but had the counter-intuitive behavior of making poly signals implicitly mono silently.

So now in the case of M != N and M != 1, we instead use as much of M as we can and pad the rest with 0. So to be clear if you ahve a polyphony 5 module and polyphony 3 modulator, the modulation amounts will be (ch1, ch2, ch3, 0, 0) whereas before this change they were (ch1, ch1, ch1, ch1, ch1), but that's really unintuitive it turns out.