### PR TITLE
Update workflow actions

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -14,7 +14,6 @@ jobs:
   modify-plugin-version:
     name: Modify plugin version
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'surge-synthesizer'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -34,7 +33,6 @@ jobs:
     name: ${{ matrix.platform }}
     needs: modify-plugin-version
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'surge-synthesizer'
     container:
       image: ghcr.io/qno/rack-plugin-toolchain-win-linux:v2
       options: --user root
@@ -67,7 +65,6 @@ jobs:
     name: mac
     needs: modify-plugin-version
     runs-on: macos-12
-    if: github.repository_owner == 'surge-synthesizer'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository_owner == 'surge-synthesizer'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: plugin-version-cache
         with:
           path: plugin.json
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: plugin-version-cache
         with:
           path: plugin.json
@@ -58,7 +58,7 @@ jobs:
           sed -i "s/-G 'MSYS Makefiles'/-DCMAKE_SYSTEM_NAME=Windows/g" Rack-SDK-win/dep.mk
           make plugin-build-${{ matrix.platform }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: ${{ env.rack-plugin-toolchain-dir }}/plugin-build
           name: ${{ matrix.platform }}
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: plugin-version-cache
         with:
           path: plugin.json
@@ -88,7 +88,7 @@ jobs:
           make -j dep
           make -j dist
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: dist
           name: mac
@@ -99,29 +99,27 @@ jobs:
     # see also https://vcvrack.com/manual/Manifest#version
     if: startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'surge-synthesizer'
     runs-on: ubuntu-latest
-    needs: [ build, build-mac ]
+    needs: [build, build-mac]
     steps:
       - uses: actions/checkout@v3
-      - uses: FranzDiebold/github-env-vars-action@v1.2.1
+      - uses: FranzDiebold/github-env-vars-action@v2
       - name: Check if plugin version matches tag
         run: |
           pluginversion=`jq -r '.version' plugin.json`
-          if [ "v$pluginversion" != "${{ env.GITHUB_REF_NAME }}" ]; then
-            echo "Plugin version from plugin.json 'v$pluginversion' doesn't match with tag version '${{ env.GITHUB_REF_NAME }}'"
+          if [ "v$pluginversion" != "${{ env.CI_REF_NAME }}" ]; then
+            echo "Plugin version from plugin.json 'v$pluginversion' doesn't match with tag version '${{ env.CI_REF_NAME }}'"
             exit 1
           fi
       - name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ env.CI_REF_NAME }}
           body: |
-            ${{ env.GITHUB_REPOSITORY_NAME }} VCV Rack Plugin ${{ env.GITHUB_REF_NAME }}
+            ${{ env.GITHUB_REPOSITORY_NAME }} VCV Rack Plugin ${{ env.CI_REF_NAME }}
           draft: false
           prerelease: false
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: _artifacts
       - name: Upload release assets
@@ -138,9 +136,9 @@ jobs:
     # see also https://vcvrack.com/manual/Manifest#version
     if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'surge-synthesizer' }}
     runs-on: ubuntu-latest
-    needs: [ build, build-mac ]
+    needs: [build, build-mac]
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: _artifacts
       - name: Delete old release assets


### PR DESCRIPTION
See discussion [automated-building-and-releasing-plugins-on-github-with-github-actions](https://community.vcvrack.com/t/automated-building-and-releasing-plugins-on-github-with-github-actions/11364/39?u=qno).

I also removed restrictions to run workflow only on origin repository, because it make no sense to me (except Releases and Nightly workflows). 