### PR TITLE
More Fixes to User Feedback

### DIFF
--- a/src/FX.h
+++ b/src/FX.h
@@ -163,6 +163,7 @@ template <int fxType> struct FX : modules::XTModule
 
         configBypass(INPUT_L, OUTPUT_L);
         configBypass(INPUT_R, OUTPUT_R);
+        snapCalculatedNames();
     }
 
     void moduleSpecificSampleRateChange() override

--- a/src/LFO.h
+++ b/src/LFO.h
@@ -254,6 +254,7 @@ struct LFO : modules::XTModule
         configOutput(OUTPUT_TRIGB, "Trigger on end of Envelope or Step Trigger B");
 
         modAssist.initialize(this);
+        snapCalculatedNames();
     }
 
     Parameter *surgeDisplayParameterForParamId(int paramId) override

--- a/src/VCO.h
+++ b/src/VCO.h
@@ -225,6 +225,7 @@ template <int oscType> struct VCO : public modules::XTModule
 
         configInput(PITCH_CV, "V/Oct");
         configInput(RETRIGGER, "Reset/Retrigger");
+        configInput(AUDIO_INPUT, "Audio Input");
         for (int m = 0; m < n_mod_inputs; ++m)
         {
             auto s = std::string("Modulation Signal ") + std::to_string(m + 1);
@@ -235,6 +236,7 @@ template <int oscType> struct VCO : public modules::XTModule
 
         memset(modulationDisplayValues, 0, (n_osc_params + 1) * sizeof(float));
         modAssist.initialize(this);
+        snapCalculatedNames();
     }
 
     void setHalfbandCharacteristics(int M, bool steep)
@@ -308,6 +310,14 @@ template <int oscType> struct VCO : public modules::XTModule
         }
         return false;
     }
+
+    bool isWTOneShot()
+    {
+        if (!VCOConfig<oscType>::requiresWavetables())
+            return false;
+        return (oscstorage->wt.flags & wtf_is_sample);
+    }
+
     float modulationDisplayValues[n_osc_params + 1];
     float modulationDisplayValue(int paramId) override
     {

--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -267,6 +267,8 @@ struct XTModule : public rack::Module
         return configSwitch<T>(paramId, 0, 1, defaultValue, name, {"Off", "On"});
     }
 
+    void snapCalculatedNames();
+
     bool isCoupledToGlobalStyle{true};
     style::XTStyle::Style localStyle{style::XTStyle::LIGHT};
     style::XTStyle::LightColor localDisplayRegionColor{style::XTStyle::ORANGE},
@@ -332,7 +334,10 @@ struct SurgeParameterParamQuantity : public rack::engine::ParamQuantity,
         return par->get_name();
     }
 
-    virtual std::string getDisplayValueString() override
+    virtual std::string getDisplayValueString() override {
+        return getDisplayValueStringForValue(getValue());
+    }
+    virtual std::string getDisplayValueStringForValue(float f)
     {
         auto par = surgepar();
         if (!par)
@@ -341,9 +346,9 @@ struct SurgeParameterParamQuantity : public rack::engine::ParamQuantity,
         }
 
         char txt[256];
-        par->get_display(txt, true, getValue());
+        par->get_display(txt, true, f);
         char talt[256];
-        par->get_display_alt(talt, true, getValue());
+        par->get_display_alt(talt, true, f);
         if (strlen(talt))
         {
             if (std::string(talt) == " ")
@@ -983,4 +988,15 @@ struct DCBlocker {
         }
     }
 };
+
+inline void XTModule::snapCalculatedNames()
+{
+    for (auto *pq : paramQuantities)
+    {
+        if (auto *s = dynamic_cast<modules::CalculatedName *>(pq))
+        {
+            pq->name = s->getCalculatedName();
+        }
+    }
+}
 } // namespace sst::surgext_rack::modules

--- a/src/XTModuleWidget.h
+++ b/src/XTModuleWidget.h
@@ -60,13 +60,9 @@ struct XTModuleWidget : public virtual rack::ModuleWidget, style::StyleParticipa
                 2 * APP->window->getMonitorRefreshRate() / rack::settings::frameSwapInterval;
             if (module)
             {
-                for (auto *pq : module->paramQuantities)
-                {
-                    if (auto *s = dynamic_cast<modules::CalculatedName *>(pq))
-                    {
-                        pq->name = s->getCalculatedName();
-                    }
-                }
+                auto xtm = dynamic_cast<modules::XTModule *>(module);
+                if (xtm)
+                    xtm->snapCalculatedNames();
             }
         }
         snapNamesEvery--;


### PR DESCRIPTION
- Snap Names on Construct. Closes #595
- Label OneShots in the display and change RESET to TRIG in one shot mode. Closes #584
- ThereAreFourLights widget fixes the RMB menu for parameters to be more discrete, in a bit of a wonky way. Closes #589