### PR TITLE
Fix Decibel Gains in Mixer, VCF and Waveshaper

### DIFF
--- a/src/Mixer.h
+++ b/src/Mixer.h
@@ -313,8 +313,10 @@ struct Mixer : modules::XTModule
 
             for (int p = 0; p < polyDepthBy4; ++p)
             {
-                oL[p] += osc[i][0][p] * modulationAssistant.valuesSSE[OSC1_LEV + i][p];
-                oR[p] += osc[i][1][p] * modulationAssistant.valuesSSE[OSC1_LEV + i][p];
+                oL[p] += osc[i][0][p] * modules::DecibelParamQuantity::ampToLinearSSE(
+                                            modulationAssistant.valuesSSE[OSC1_LEV + i][p]);
+                oR[p] += osc[i][1][p] * modules::DecibelParamQuantity::ampToLinearSSE(
+                                            modulationAssistant.valuesSSE[OSC1_LEV + i][p]);
             }
         }
 
@@ -325,10 +327,12 @@ struct Mixer : modules::XTModule
                 auto col = std::clamp(modulationAssistant.values[NOISE_COL][p], -1.f, 1.f);
                 oL[p >> 2][p % 4] += correlated_noise_o2mk2_storagerng(
                                          noisegen[p][0][0], noisegen[p][0][1], col, storage.get()) *
-                                     modulationAssistant.values[NOISE_LEV][p];
+                                     modules::DecibelParamQuantity::ampToLinear(
+                                         modulationAssistant.values[NOISE_LEV][p]);
                 oR[p >> 2][p % 4] += correlated_noise_o2mk2_storagerng(
                                          noisegen[p][1][0], noisegen[p][1][1], col, storage.get()) *
-                                     modulationAssistant.values[NOISE_LEV][p];
+                                     modules::DecibelParamQuantity::ampToLinear(
+                                         modulationAssistant.values[NOISE_LEV][p]);
             }
         }
 
@@ -336,10 +340,12 @@ struct Mixer : modules::XTModule
         {
             for (int p = 0; p < polyDepthBy4; ++p)
             {
-                oL[p] +=
-                    osc[osc1][0][p] * osc[osc2][0][p] * modulationAssistant.valuesSSE[RM1X2_LEV][p];
-                oR[p] +=
-                    osc[osc1][1][p] * osc[osc2][1][p] * modulationAssistant.valuesSSE[RM1X2_LEV][p];
+                oL[p] += osc[osc1][0][p] * osc[osc2][0][p] *
+                         modules::DecibelParamQuantity::ampToLinearSSE(
+                             modulationAssistant.valuesSSE[RM1X2_LEV][p]);
+                oR[p] += osc[osc1][1][p] * osc[osc2][1][p] *
+                         modules::DecibelParamQuantity::ampToLinearSSE(
+                             modulationAssistant.valuesSSE[RM1X2_LEV][p]);
             }
         }
 
@@ -347,17 +353,21 @@ struct Mixer : modules::XTModule
         {
             for (int p = 0; p < polyDepthBy4; ++p)
             {
-                oL[p] +=
-                    osc[osc3][0][p] * osc[osc2][0][p] * modulationAssistant.valuesSSE[RM2X3_LEV][p];
-                oR[p] +=
-                    osc[osc3][1][p] * osc[osc2][1][p] * modulationAssistant.valuesSSE[RM2X3_LEV][p];
+                oL[p] += osc[osc3][0][p] * osc[osc2][0][p] *
+                         modules::DecibelParamQuantity::ampToLinearSSE(
+                             modulationAssistant.valuesSSE[RM2X3_LEV][p]);
+                oR[p] += osc[osc3][1][p] * osc[osc2][1][p] *
+                         modules::DecibelParamQuantity::ampToLinearSSE(
+                             modulationAssistant.valuesSSE[RM2X3_LEV][p]);
             }
         }
 
         for (int p = 0; p < polyDepthBy4; ++p)
         {
-            oL[p] *= modulationAssistant.valuesSSE[GAIN][p];
-            oR[p] *= modulationAssistant.valuesSSE[GAIN][p];
+            oL[p] *= modules::DecibelParamQuantity::ampToLinearSSE(
+                modulationAssistant.valuesSSE[GAIN][p]);
+            oR[p] *= modules::DecibelParamQuantity::ampToLinearSSE(
+                modulationAssistant.valuesSSE[GAIN][p]);
             oL[p] *= SURGE_TO_RACK_OSC_MUL;
             oR[p] *= SURGE_TO_RACK_OSC_MUL;
 

--- a/src/VCF.h
+++ b/src/VCF.h
@@ -393,10 +393,10 @@ struct VCF : public modules::XTModule
 
             for (int i = 0; i < MAX_POLY >> 2; ++i)
             {
-                auto tig = modulationAssistant.valuesSSE[IN_GAIN][i];
+                auto tig = modules::DecibelParamQuantity::ampToLinearSSE(modulationAssistant.valuesSSE[IN_GAIN][i]);
                 dInGain[i] = _mm_mul_ps(_mm_sub_ps(tig, currentInGain[i]), oneOverBlock);
 
-                auto tog = modulationAssistant.valuesSSE[OUT_GAIN][i];
+                auto tog = modules::DecibelParamQuantity::ampToLinearSSE(modulationAssistant.valuesSSE[OUT_GAIN][i]);
                 dOutGain[i] = _mm_mul_ps(_mm_sub_ps(tog, currentOutGain[i]), oneOverBlock);
 
                 auto tmix = modulationAssistant.valuesSSE[MIX][i];

--- a/src/Waveshaper.h
+++ b/src/Waveshaper.h
@@ -379,14 +379,14 @@ struct Waveshaper : public modules::XTModule
             auto in = _mm_mul_ps(_mm_load_ps(iv), rackToSurgeOsc);
             in = _mm_add_ps(in, _mm_set1_ps(mv[BIAS - DRIVE][0]));
             auto fin = wsPtr(&wss[0], in, drive);
-            fin = _mm_mul_ps(fin, _mm_set1_ps(mv[OUT_GAIN - DRIVE][0]));
+            fin = _mm_mul_ps(fin, modules::DecibelParamQuantity::ampToLinearSSE(_mm_set1_ps(mv[OUT_GAIN - DRIVE][0])));
             fin = _mm_mul_ps(fin, surgeToRackOsc);
             _mm_store_ps(ov, fin);
 
             outputs[OUTPUT_L].setVoltage(ov[0]);
             outputs[OUTPUT_R].setVoltage(ov[1]);
         }
-        if (stereoStack)
+        else if (stereoStack)
         {
             // We can make this more efficient with smarter SIMD loads later
             float tmpVal alignas(16)[MAX_POLY << 2];
@@ -431,7 +431,7 @@ struct Waveshaper : public modules::XTModule
                 auto in = _mm_mul_ps(_mm_loadu_ps(tmpVal + (i << 2)), rackToSurgeOsc);
                 in = _mm_add_ps(in, mods[BIAS - DRIVE]);
                 auto fin = wsPtr(&wss[i], in, mods[0 /* DRIVE - DRIVE */]);
-                fin = _mm_mul_ps(fin, mods[OUT_GAIN - DRIVE]);
+                fin = _mm_mul_ps(fin, modules::DecibelParamQuantity::ampToLinearSSE(mods[OUT_GAIN - DRIVE]));
                 fin = _mm_mul_ps(fin, surgeToRackOsc);
                 _mm_storeu_ps(tmpValOut + (i << 2), fin);
             }
@@ -469,7 +469,7 @@ struct Waveshaper : public modules::XTModule
                 auto in = _mm_mul_ps(_mm_loadu_ps(iv + (i << 2)), rackToSurgeOsc);
                 in = _mm_add_ps(in, mvsse[BIAS - DRIVE][i]);
                 auto fin = wsPtr(&wss[i], in, drive);
-                fin = _mm_mul_ps(fin, mvsse[OUT_GAIN - DRIVE][i]);
+                fin = _mm_mul_ps(fin, modules::DecibelParamQuantity::ampToLinearSSE(mvsse[OUT_GAIN - DRIVE][i]));
                 fin = _mm_mul_ps(fin, surgeToRackOsc);
                 _mm_storeu_ps(ov + (i << 2), fin);
             }


### PR DESCRIPTION
1. Displayed scale of db was wrong
2. Linear scale of knobs mis-matched surge internals

so

1. Change the db display to be correct; Now setting gain to -4 on a signal does the exact same thing as mixmaster
2. Change the db scaling to be cubic, like the surge mixer does, giving a bigger upside range (to 18db) and finer control on the downside, especially when modulating.