### PR TITLE
TempoSync Display and LFO Manual Poly Fixes

### DIFF
--- a/src/LFO.cpp
+++ b/src/LFO.cpp
@@ -46,8 +46,9 @@ struct LFOWidget : widgets::XTModuleWidget
             m->paramQuantities[M::BROADCAST_TRIG_TO_POLY]->getValue());
 
         p->addChild(rack::createMenuItem(
-            "Trigger Sets Polyphony If Connected", CHECKMARK(tt == M::FOLLOW_TRIG_POLY), [m]() {
-                m->paramQuantities[M::BROADCAST_TRIG_TO_POLY]->setValue(M::FOLLOW_TRIG_POLY);
+            "Trigger Sets Polyphony If Connected", CHECKMARK(tt == M::FOLLOW_TRIG_POLY), [m, tt]() {
+                m->paramQuantities[M::BROADCAST_TRIG_TO_POLY]->setValue(
+                    tt == M::FOLLOW_TRIG_POLY ? M::TAKE_CHANNEL_0 : M::FOLLOW_TRIG_POLY);
             }));
 
         p->addChild(rack::createMenuItem(

--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -345,6 +345,13 @@ struct SurgeParameterParamQuantity : public rack::engine::ParamQuantity,
             return ParamQuantity::getDisplayValueString();
         }
 
+        /* So the param quantity has the value of the knob but that gets rounded
+         * to the nearest temposync in setval_f01. Fine whatever except when stringifying
+         * then we need to use the rounded value to match.
+         */
+        if (par->temposync)
+            f = par->get_value_f01();
+
         char txt[256];
         par->get_display(txt, true, f);
         char talt[256];


### PR DESCRIPTION
1. Temposync display used a mis-rounded value so the tooltip didnt always match the behavior. Fix and closes #619
2. Actually *set* the polyphony manual mode in the menu so it works. Duh. Closes #618