### PR TITLE
Fix a leak of knob shadow

### DIFF
--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -284,6 +284,15 @@ struct KnobN : public rack::componentlibrary::RoundKnob, style::StyleParticipant
     std::string knobPointerAsset, knobBackgroundAsset;
 
     KnobN() {}
+    ~KnobN() {
+        // we removed shadow so it won't be deleted by the sweep
+        if (shadow)
+        {
+            delete shadow;
+            shadow = nullptr;
+        }
+    }
+
     Widget *asWidget() override { return this; }
 
     bool isBipolar()
@@ -321,7 +330,10 @@ struct KnobN : public rack::componentlibrary::RoundKnob, style::StyleParticipant
         maxAngle = M_PI * (180 - angleSpreadDegrees) / 180;
 
         setupWidgets();
-        fb->removeChild(shadow);
+        if (shadow)
+        {
+            fb->removeChild(shadow);
+        }
     }
 
     virtual void setupProperties() {}


### PR DESCRIPTION
We remove the RoundKnob::shadow member in KnobN. But Widget::removeChild doesn't delete the widget rather it transfers ownership to the caller, so make sure to delete in my constructor.

Don't delelte when we remove incase a base class decides to touch it for some reason.