### PR TITLE
FPU Guard isn't needed

### DIFF
--- a/src/Delay.h
+++ b/src/Delay.h
@@ -236,7 +236,7 @@ struct Delay : modules::XTModule
     float modVal{0}, dMod{0}, modPhase{0};
     void process(const ProcessArgs &args) override
     {
-        auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
+        // auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
 
         if (inputs[INPUT_CLOCK].isConnected())
             clockProc.process(this, INPUT_CLOCK);

--- a/src/DelayLineByFreq.h
+++ b/src/DelayLineByFreq.h
@@ -93,7 +93,7 @@ struct DelayLineByFreq : modules::XTModule
 
     void process(const ProcessArgs &args) override
     {
-        auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
+        // auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
 
         int cc = std::max(inputs[INPUT_L].getChannels(), 1);
 

--- a/src/FX.h
+++ b/src/FX.h
@@ -406,7 +406,7 @@ template <int fxType> struct FX : modules::XTModule
 
     void process(const typename rack::Module::ProcessArgs &args) override
     {
-        auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
+        // auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
 
         if constexpr (FXConfig<fxType>::usesClock())
         {

--- a/src/Mixer.h
+++ b/src/Mixer.h
@@ -248,7 +248,7 @@ struct Mixer : modules::XTModule
 
     void process(const ProcessArgs &args) override
     {
-        auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
+        // auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
 
         if (blockPos == slowUpdate)
         {

--- a/src/VCF.h
+++ b/src/VCF.h
@@ -312,7 +312,7 @@ struct VCF : public modules::XTModule
 
     void process(const typename rack::Module::ProcessArgs &args) override
     {
-        auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
+        // auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
 
         auto ftype = (sst::filters::FilterType)(int)(std::round(params[VCF_TYPE].getValue()));
         auto fsubtype =

--- a/src/VCO.h
+++ b/src/VCO.h
@@ -427,7 +427,7 @@ template <int oscType> struct VCO : public modules::XTModule
 
     void process(const typename rack::Module::ProcessArgs &args) override
     {
-        auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
+        // auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
 
         int nChan = polyChannelCount();
         outputs[OUTPUT_L].setChannels(nChan);

--- a/src/Waveshaper.h
+++ b/src/Waveshaper.h
@@ -268,7 +268,7 @@ struct Waveshaper : public modules::XTModule
 
     void process(const typename rack::Module::ProcessArgs &args) override
     {
-        auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
+        // auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
 
         auto wstype =
             (sst::waveshapers::WaveshaperType)(int)(std::round(params[WSHP_TYPE].getValue()));


### PR DESCRIPTION
On discord, Oct 17, Vortico told me:

DSP threads run with
    _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
    _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
    _MM_SET_ROUNDING_MODE(_MM_ROUND_NEAREST);

regardless of standalone or plugin.

and the FPU guard here seems to take a lot of CPU in high thread rosetta situations. So don't do it and rely on the rac environment.