### PR TITLE
Alpha label; FClose fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Surge XT VCV Modules Changelog
 
-## 2.1 - In Beta Now
+## 2.1 - In Beta Now (this as of a97451f2 / Nov 23)
 
 - New Modules
     - EGxVCA (still in development)

--- a/src/EGxVCA.cpp
+++ b/src/EGxVCA.cpp
@@ -35,7 +35,13 @@ struct EGxVCAWidget : public widgets::XTModuleWidget
             toggles[mod]->onToggle(!toggles[mod]->pressedState);
     }
 
-    void appendModuleSpecificMenu(rack::ui::Menu *menu) override {}
+    void appendModuleSpecificMenu(rack::ui::Menu *menu) override
+    {
+        menu->addChild(new rack::ui::MenuSeparator);
+        /*
+         * Clock entries
+         */
+    }
 };
 
 EGxVCAWidget::EGxVCAWidget(sst::surgext_rack::egxvca::ui::EGxVCAWidget::M *module)
@@ -49,6 +55,7 @@ EGxVCAWidget::EGxVCAWidget(sst::surgext_rack::egxvca::ui::EGxVCAWidget::M *modul
 
     auto bg = new widgets::Background(box.size, "EG x VCA", "fx", "BlankNoDisplay");
     addChild(bg);
+    bg->addAlpha();
 
     auto col = std::vector<float>();
     for (int i = 0; i < 4; ++i)

--- a/src/EGxVCA.h
+++ b/src/EGxVCA.h
@@ -27,6 +27,7 @@
  *    - Retrigger / Gate controls
  *    - DAHD mode v DASDR mode
  *    - Pan implementation (follow models from MixMaster probably)
+ *    - SIMD for response etc... and be more parsimonious with cube etc...
  * - UI
  *    - LintBuddy/Label inputs outputs mods etc
  *    - Correct labels and param quantities for the modulator knobs
@@ -297,7 +298,7 @@ struct EGxVCA : modules::XTModule
 
                 if (doAttack[c])
                 {
-                    processors[c]->attack();
+                    processors[c]->attackFrom(processors[c]->get_output(0));
                     doAttack[c] = false;
                 }
                 if (doRelease[c])

--- a/src/XTStyle.cpp
+++ b/src/XTStyle.cpp
@@ -32,8 +32,10 @@ void XTStyle::initialize()
     json_t *fd{nullptr};
     auto *fptr = std::fopen(defaultsFile.c_str(), "r");
     if (fptr)
+    {
         fd = json_loadf(fptr, 0, &error);
-    DEFER({ std::fclose(fptr); });
+        DEFER({ std::fclose(fptr); });
+    }
     if (!fd)
     {
         setGlobalStyle(MID);

--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -262,8 +262,32 @@ struct Background : public rack::TransparentWidget, style::StyleParticipant
             titleLabel->tracking = 0.7;
             addChild(titleLabel);
         }
+
+        if (alphaWarning)
+        {
+            alphaWarning->dirty = true;
+        }
+    }
+
+    BufferedDrawFunctionWidget *alphaWarning{nullptr};
+    void addAlpha()
+    {
+        alphaWarning = new BufferedDrawFunctionWidget(rack::Vec(0,0), rack::Vec(100,20),[this](auto vg){ drawAlpha(vg);});
+        addChild(alphaWarning);
+    }
+    void drawAlpha(NVGcontext *vg)
+    {
+        nvgBeginPath(vg);
+        nvgFontFaceId(vg, style()->fontIdBold(vg));
+        nvgFontSize(vg, 18);
+        nvgTextAlign(vg, NVG_ALIGN_TOP|NVG_ALIGN_LEFT);
+        nvgFillColor(vg, style()->getColor(style::XTStyle::TEXT_LABEL));
+        nvgText(vg, 1.5, 1.5, "ALPHA", nullptr);
+        nvgFillColor(vg, nvgRGB(255,0,0));
+        nvgText(vg, 1, 1, "ALPHA", nullptr);
     }
 };
+
 
 struct ModRingKnob;
 


### PR DESCRIPTION
1. add a 'alpha' label which youc an slap on new modules since folks are using 2.1 while we wait for the library

2. add the alpha label to EGxVCA

3. Fix an fclose-on-nullptr case which may be crashing arch