### PR TITLE
Workaround SDK 2.2 Docker Bug

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -2,8 +2,7 @@ name: Build VCV Rack Plugin
 on: [push, pull_request]
 
 env:
-  rack-sdk-version: 2.1.2
-  cross-rack-sdk-version: 2.2.0
+  rack-sdk-version: 2.2.0
   rack-plugin-toolchain-dir: /home/build/rack-plugin-toolchain
 
 defaults:
@@ -54,7 +53,7 @@ jobs:
         run: |
           export PLUGIN_DIR=$GITHUB_WORKSPACE
           pushd ${{ env.rack-plugin-toolchain-dir }}
-          sed -i "s/-G 'MSYS Makefiles'/-DCMAKE_SYSTEM_NAME=Windows/g" Rack-SDK-win/dep.mk
+          sed -i "s/-G 'MSYS Makefiles'/-DCMAKE_SYSTEM_NAME=Windows/g" Rack-SDK-win-x64/dep.mk
           make plugin-build-${{ matrix.platform }}
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -78,7 +77,7 @@ jobs:
       - name: Get Rack-SDK
         run: |
           pushd $HOME
-          curl -o Rack-SDK.zip https://vcvrack.com/downloads/Rack-SDK-${{ env.cross-rack-sdk-version }}-mac-arm64.zip
+          curl -o Rack-SDK.zip https://vcvrack.com/downloads/Rack-SDK-${{ env.rack-sdk-version }}-mac-arm64.zip
           unzip Rack-SDK.zip
           popd
           patch -ruN -d $HOME/Rack-SDK < ./scripts/rack-sdk-220-cross.patch
@@ -111,7 +110,7 @@ jobs:
       - name: Get Rack-SDK
         run: |
           pushd $HOME
-          curl -o Rack-SDK.zip https://vcvrack.com/downloads/Rack-SDK-${{ env.rack-sdk-version }}-mac.zip
+          curl -o Rack-SDK.zip https://vcvrack.com/downloads/Rack-SDK-${{ env.rack-sdk-version }}-mac-x64.zip
           unzip Rack-SDK.zip
       - name: Build plugin
         run: |

--- a/scripts/drun.sh
+++ b/scripts/drun.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+docker run --rm --interactive --tty \
+	--volume=/home/paul/dev/surge-rack:/home/build/rack-plugin-toolchain/surge-rack \
+	--env PLUGIN_DIR=surge-rack \
+	ghcr.io/qno/rack-plugin-toolchain-win-linux:latest \
+	/bin/bash
+
+	#rack-plugin-toolchain:$(DOCKER_IMAGE_VERSION) \

--- a/src/FX.cpp
+++ b/src/FX.cpp
@@ -13,6 +13,10 @@
  * https://github.com/surge-synthesizer/surge-rack/
  */
 
+#if ARCH_LIN
+#include <immintrin.h>
+#endif
+
 #include "FX.h"
 #include "FXConfig.h"
 #include "XTModuleWidget.h"

--- a/src/VCO.cpp
+++ b/src/VCO.cpp
@@ -13,6 +13,10 @@
  * https://github.com/surge-synthesizer/surge-rack/
  */
 
+#if ARCH_LIN
+#include <immintrin.h>
+#endif
+
 #include "VCO.h"
 #include "VCOConfig.h"
 #include "XTWidgets.h"


### PR DESCRIPTION
SDK 2.2 has a header order fragility problem. This works around it allowintg 2.2.0 docker builds to work on linux.