### PR TITLE
Turn off AirWindows unused build; add Install docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 
 $(libsurge):
 	# Out-of-source build dir
-	cd surge && $(CMAKE) -B../$(SURGE_BLD) -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DSURGE_SKIP_JUCE_FOR_RACK=TRUE -DSURGE_SKIP_LUA=TRUE -DSURGE_COMPILE_BLOCK_SIZE=8 $(EXTRA_CMAKE)
+	cd surge && $(CMAKE) -B../$(SURGE_BLD) -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DSURGE_SKIP_JUCE_FOR_RACK=TRUE -DSURGE_SKIP_LUA=TRUE -DSURGE_SKIP_AIRWINDOWS=TRUE -DSURGE_COMPILE_BLOCK_SIZE=8 $(EXTRA_CMAKE)
 	# -DSURGE_SANITIZE=TRUE
 	# $(CMAKE) --build doesn't work here since the arguments are set for stage one only, so use make directly.
 	cd $(SURGE_BLD) && make -j 4 surge-common

--- a/docs/install_steps.md
+++ b/docs/install_steps.md
@@ -1,0 +1,54 @@
+# How to do a new install to the library
+
+Basically you need to
+
+1. Make sure CI builds
+2. Potentially check in the docker image (although CI *should* cover that)
+3. Make a branch
+4. Update plugin.json in the branch
+4. Tag, Commit and Push atomically
+5. cancel the release branch build
+6. Submit to the library
+
+So here's how
+
+## Make sure CI builds and Check in Docker
+
+CI is easy. Just you know, merge.
+
+The docker image can be run with `./scripts/drun.sh` which maps paths.
+If you aren't baconpauls particular ubuntu image you may need to modify
+some of the paths. One in the image, if you keep the envs and paths set
+up, you can do `make plugin-linux-build` and it will do a toolchain
+equivalent build
+
+## Branch, update plugin.json, Tag, commit, Push atomically
+
+We are using branches `releases-xt/v(version)` and tag `v(version)` so
+
+```bash
+git checkout -b releases-xt/v2.0.3.0
+vi plugin.json  # Edit the 'version' to match
+git add plugin.json
+# you may want to cherry pick other items in or out here
+git commit -m "2.0.3.0 release branch"
+git tag v2.0.3.0 -m "2.0.3.0 release tag"
+git push --atomic upstream-write releases-xt/v2.0.3.0 v2.0.3.0
+```
+
+## Cancel one of the github actions builds associated with the branch
+
+Our CI actions run on a push of a tag or a branch, but only make a
+release on the tag, so that branch will spanner the nightly. We
+should fix this but for now, just go to the actions tab on github
+and cancel the run which is happening for `releases-xt/v2.0.3.0` but
+not the one for `v2.0.3.0`. Soon enough a release build will appear
+
+## Submit to the library
+
+```
+RACK_DIR=../R2X86/Rack-SDK make issue_blurb
+```
+
+that will make a blurb which you can paste into https://github.com/VCVRack/community/issues/745
+and then the machinery will start churning.

--- a/src/EGxVCA.cpp
+++ b/src/EGxVCA.cpp
@@ -53,10 +53,9 @@ struct EGxVCAWidget : public widgets::XTModuleWidget
             rack::createMenuItem("Clock in QuarterNotes", CHECKMARK(t == cp_t::QUARTER_NOTE),
                                  [xtm]() { xtm->clockProc.clockStyle = cp_t::QUARTER_NOTE; }));
 
-        menu->addChild(rack::createMenuItem(
-            "Clock in BPM CV", CHECKMARK(t == cp_t::BPM_VOCT),
-            [xtm]() { xtm->clockProc.clockStyle = cp_t::BPM_VOCT; }));
-
+        menu->addChild(
+            rack::createMenuItem("Clock in BPM CV", CHECKMARK(t == cp_t::BPM_VOCT),
+                                 [xtm]() { xtm->clockProc.clockStyle = cp_t::BPM_VOCT; }));
     }
 };
 
@@ -64,11 +63,11 @@ struct EnvCurveWidget : rack::Widget, style::StyleParticipant
 {
     widgets::BufferedDrawFunctionWidget *bdw{nullptr}, *bdwCurve{nullptr};
     EGxVCA *module{nullptr};
-    EnvCurveWidget(const rack::Vec &pos, const rack::Vec &size, EGxVCA *module)
+    EnvCurveWidget(const rack::Vec &pos, const rack::Vec &size, EGxVCA *md)
     {
         box.pos = pos;
         box.size = size;
-        module = module;
+        module = md;
 
         bdw = new widgets::BufferedDrawFunctionWidget(rack::Vec(0, 0), size,
                                                       [this](auto vg) { drawBg(vg); });
@@ -108,11 +107,11 @@ struct ResponseMeterWidget : rack::Widget, style::StyleParticipant
 {
     widgets::BufferedDrawFunctionWidget *bdw{nullptr}, *bdwCurve{nullptr};
     EGxVCA *module{nullptr};
-    ResponseMeterWidget(const rack::Vec &pos, const rack::Vec &size, EGxVCA *module)
+    ResponseMeterWidget(const rack::Vec &pos, const rack::Vec &size, EGxVCA *md)
     {
         box.pos = pos;
         box.size = size;
-        module = module;
+        module = md;
 
         bdw = new widgets::BufferedDrawFunctionWidget(rack::Vec(0, 0), size,
                                                       [this](auto vg) { drawBg(vg); });


### PR DESCRIPTION
1. Bring in the surge diff which turns off airwindows builds optionally and do that in our dep stage to make CI faster. Closes #652
2. Add a small doc on how to prep an install so I don't have to remember those steps next time. Closes #660