### PR TITLE
Centralize some more clock stuff

### DIFF
--- a/src/Delay.cpp
+++ b/src/Delay.cpp
@@ -34,17 +34,7 @@ struct DelayWidget : widgets::XTModuleWidget
     {
         if (!module)
             return;
-        auto xtm = static_cast<Delay *>(module);
-        typedef modules::ClockProcessor<Delay> cp_t;
-        menu->addChild(new rack::ui::MenuSeparator);
-        auto t = xtm->clockProc.clockStyle;
-        menu->addChild(
-            rack::createMenuItem("Clock in QuarterNotes", CHECKMARK(t == cp_t::QUARTER_NOTE),
-                                 [xtm]() { xtm->clockProc.clockStyle = cp_t::QUARTER_NOTE; }));
-
-        menu->addChild(
-            rack::createMenuItem("Clock in BPM CV", CHECKMARK(t == cp_t::BPM_VOCT),
-                                 [xtm]() { xtm->clockProc.clockStyle = cp_t::BPM_VOCT; }));
+        addClockMenu<Delay>(menu);
     }
 
     void selectModulator(int mod) override

--- a/src/Delay.h
+++ b/src/Delay.h
@@ -83,7 +83,8 @@ struct Delay : modules::XTModule
     modules::MonophonicModulationAssistant<Delay, n_delay_params, TIME_L, n_mod_inputs,
                                            DELAY_MOD_INPUT>
         modulationAssistant;
-    modules::ClockProcessor<Delay> clockProc;
+    typedef modules::ClockProcessor<Delay> clockProcessor_t;
+    clockProcessor_t clockProc;
 
     float tsV(float f)
     {
@@ -324,20 +325,11 @@ struct Delay : modules::XTModule
     json_t *makeModuleSpecificJson() override
     {
         auto fx = json_object();
-        json_object_set(fx, "clockStyle", json_integer((int)clockProc.clockStyle));
+        clockProc.toJson(fx);
         return fx;
     }
 
-    void readModuleSpecificJson(json_t *modJ) override
-    {
-        auto cs = json_object_get(modJ, "clockStyle");
-        if (cs)
-        {
-            auto csv = json_integer_value(cs);
-            clockProc.clockStyle =
-                static_cast<typename modules::ClockProcessor<Delay>::ClockStyle>(csv);
-        }
-    }
+    void readModuleSpecificJson(json_t *modJ) override { clockProc.fromJson(modJ); }
 };
 } // namespace sst::surgext_rack::delay
 #endif

--- a/src/EGxVCA.cpp
+++ b/src/EGxVCA.cpp
@@ -44,18 +44,7 @@ struct EGxVCAWidget : public widgets::XTModuleWidget
         /*
          * Clock entries
          */
-        auto xtm = static_cast<M *>(module);
-
-        typedef modules::ClockProcessor<EGxVCA> cp_t;
-        menu->addChild(new rack::ui::MenuSeparator);
-        auto t = xtm->clockProc.clockStyle;
-        menu->addChild(
-            rack::createMenuItem("Clock in QuarterNotes", CHECKMARK(t == cp_t::QUARTER_NOTE),
-                                 [xtm]() { xtm->clockProc.clockStyle = cp_t::QUARTER_NOTE; }));
-
-        menu->addChild(
-            rack::createMenuItem("Clock in BPM CV", CHECKMARK(t == cp_t::BPM_VOCT),
-                                 [xtm]() { xtm->clockProc.clockStyle = cp_t::BPM_VOCT; }));
+        addClockMenu<EGxVCA>(menu);
     }
 };
 

--- a/src/EGxVCA.h
+++ b/src/EGxVCA.h
@@ -235,7 +235,8 @@ struct EGxVCA : modules::XTModule
     {
         clockProc.setSampleRate(APP->engine->getSampleRate());
     }
-    modules::ClockProcessor<EGxVCA> clockProc;
+    typedef modules::ClockProcessor<EGxVCA> clockProcessor_t;
+    clockProcessor_t clockProc;
 
     std::string getName() override { return std::string("EGxVCA"); }
     int processCount{BLOCK_SIZE};
@@ -337,7 +338,7 @@ struct EGxVCA : modules::XTModule
             }
             processCount = 0;
         }
-      
+
         // ToDo - SIMDize
         for (int c = 0; c < nChan; ++c)
         {
@@ -391,21 +392,12 @@ struct EGxVCA : modules::XTModule
     {
         auto vc = json_object();
 
-        json_object_set(vc, "clockStyle", json_integer((int)clockProc.clockStyle));
+        clockProc.toJson(vc);
 
         return vc;
     }
 
-    void readModuleSpecificJson(json_t *modJ) override
-    {
-        auto cs = json_object_get(modJ, "clockStyle");
-        if (cs)
-        {
-            auto csv = json_integer_value(cs);
-            clockProc.clockStyle =
-                static_cast<typename modules::ClockProcessor<EGxVCA>::ClockStyle>(csv);
-        }
-    }
+    void readModuleSpecificJson(json_t *modJ) override { clockProc.fromJson(modJ); }
 };
 } // namespace sst::surgext_rack::egxvca
 #endif

--- a/src/FX.cpp
+++ b/src/FX.cpp
@@ -63,16 +63,7 @@ template <int fxType> struct FXWidget : public widgets::XTModuleWidget
 
         if (FXConfig<fxType>::usesClock())
         {
-            typedef modules::ClockProcessor<FX<fxType>> cp_t;
-            menu->addChild(new rack::ui::MenuSeparator);
-            auto t = xtm->clockProc.clockStyle;
-            menu->addChild(
-                rack::createMenuItem("Clock in QuarterNotes", CHECKMARK(t == cp_t::QUARTER_NOTE),
-                                     [xtm]() { xtm->clockProc.clockStyle = cp_t::QUARTER_NOTE; }));
-
-            menu->addChild(rack::createMenuItem(
-                "Clock in BPM CV", CHECKMARK(t == modules::ClockProcessor<FX<fxType>>::BPM_VOCT),
-                [xtm]() { xtm->clockProc.clockStyle = cp_t::BPM_VOCT; }));
+            addClockMenu<FX<fxType>>(menu);
         }
     }
 };

--- a/src/FX.h
+++ b/src/FX.h
@@ -176,7 +176,8 @@ template <int fxType> struct FX : modules::XTModule
     {
         clockProc.setSampleRate(APP->engine->getSampleRate());
     }
-    modules::ClockProcessor<FX<fxType>> clockProc;
+    typedef modules::ClockProcessor<FX<fxType>> clockProcessor_t;
+    clockProcessor_t clockProc;
 
     // If you need em you have a scnmidt trigger for extra inputs
     // add one since 0 length arrays are gross and its just memory smidges
@@ -736,7 +737,7 @@ template <int fxType> struct FX : modules::XTModule
         }
         if (FXConfig<fxType>::usesClock())
         {
-            json_object_set(fx, "clockStyle", json_integer((int)clockProc.clockStyle));
+            clockProc.toJson(fx);
         }
 
         if (FXConfig<fxType>::allowsPolyphony())
@@ -767,13 +768,7 @@ template <int fxType> struct FX : modules::XTModule
         }
         if (FXConfig<fxType>::usesClock())
         {
-            auto cs = json_object_get(modJ, "clockStyle");
-            if (cs)
-            {
-                auto csv = json_integer_value(cs);
-                clockProc.clockStyle =
-                    static_cast<typename modules::ClockProcessor<FX<fxType>>::ClockStyle>(csv);
-            }
+           clockProc.fromJson(modJ);
         }
 
         if (FXConfig<fxType>::allowsPolyphony())

--- a/src/LFO.cpp
+++ b/src/LFO.cpp
@@ -142,15 +142,7 @@ struct LFOWidget : widgets::XTModuleWidget
                                             [m, wtE, wtR]() { m->setWhichTemposyc(!wtR, wtE); }));
         menu->addChild(rack::createMenuItem("Temposync Env Rates", CHECKMARK(wtE),
                                             [m, wtE, wtR]() { m->setWhichTemposyc(wtR, !wtE); }));
-        menu->addChild(new rack::MenuSeparator);
-
-        auto t = m->clockProc.clockStyle;
-        menu->addChild(
-            rack::createMenuItem("Clock in QuarterNotes", CHECKMARK(t == cp_t::QUARTER_NOTE),
-                                 [m]() { m->clockProc.clockStyle = cp_t::QUARTER_NOTE; }));
-
-        menu->addChild(rack::createMenuItem("Clock in BPM CV", CHECKMARK(t == cp_t::BPM_VOCT),
-                                            [m]() { m->clockProc.clockStyle = cp_t::BPM_VOCT; }));
+        addClockMenu<LFO>(menu);
     }
 
     void selectModulator(int mod) override

--- a/src/LFO.h
+++ b/src/LFO.h
@@ -321,7 +321,8 @@ struct LFO : modules::XTModule
     int priorIntPhase[MAX_POLY], endPhaseCountdown[MAX_POLY], priorEnvStage[MAX_POLY];
     int trigABCountdown[2][MAX_POLY];
 
-    modules::ClockProcessor<LFO> clockProc;
+    typedef modules::ClockProcessor<LFO> clockProcessor_t;
+    clockProcessor_t clockProc;
 
     void activateTempoSync()
     {
@@ -711,7 +712,7 @@ struct LFO : modules::XTModule
     json_t *makeModuleSpecificJson() override
     {
         auto fx = json_object();
-        json_object_set(fx, "clockStyle", json_integer((int)clockProc.clockStyle));
+        clockProc.toJson(fx);
         json_object_set(fx, "retriggerFromZero", json_boolean(retriggerFromZero));
         json_object_set(fx, "onepoleFactor", json_real(onepoleFactor));
         return fx;
@@ -719,15 +720,7 @@ struct LFO : modules::XTModule
 
     void readModuleSpecificJson(json_t *modJ) override
     {
-        {
-            auto cs = json_object_get(modJ, "clockStyle");
-            if (cs)
-            {
-                auto csv = json_integer_value(cs);
-                clockProc.clockStyle =
-                    static_cast<typename modules::ClockProcessor<LFO>::ClockStyle>(csv);
-            }
-        }
+        clockProc.fromJson(modJ);
         {
             auto rt = json_object_get(modJ, "retriggerFromZero");
             if (rt)

--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -987,6 +987,22 @@ template <typename T> struct ClockProcessor
         sampleRate = sr;
         sampleRateInv = 1.f / sr;
     }
+
+    void toJson(json_t *onto)
+    {
+        json_object_set(onto, "clockStyle", json_integer((int)clockStyle));
+    }
+
+    void fromJson(json_t *modJ)
+    {
+        auto cs = json_object_get(modJ, "clockStyle");
+        if (cs)
+        {
+            auto csv = json_integer_value(cs);
+            clockStyle =
+                static_cast<ClockStyle>(csv);
+        }
+    }
 };
 
 struct DCBlocker {

--- a/src/XTModuleWidget.h
+++ b/src/XTModuleWidget.h
@@ -78,6 +78,22 @@ struct XTModuleWidget : public virtual rack::ModuleWidget, style::StyleParticipa
     virtual void selectModulator(int whichMod) {}
 
     virtual void appendModuleSpecificMenu(rack::ui::Menu *menu) {}
+
+    template <typename T> void addClockMenu(rack::ui::Menu *menu)
+    {
+        typedef typename T::clockProcessor_t cp_t;
+        auto xtm = static_cast<T *>(module);
+
+        menu->addChild(new rack::ui::MenuSeparator);
+        auto t = xtm->clockProc.clockStyle;
+        menu->addChild(
+            rack::createMenuItem("Clock in QuarterNotes", CHECKMARK(t == cp_t::QUARTER_NOTE),
+                                 [xtm]() { xtm->clockProc.clockStyle = cp_t::QUARTER_NOTE; }));
+
+        menu->addChild(
+            rack::createMenuItem("Clock in BPM CV", CHECKMARK(t == cp_t::BPM_VOCT),
+                                 [xtm]() { xtm->clockProc.clockStyle = cp_t::BPM_VOCT; }));
+    }
     virtual void appendContextMenu(rack::ui::Menu *menu) override;
 
   protected:


### PR DESCRIPTION
Clock caluclation was all in one place, but the json streaming and menu handling was copied and pasted. With a few more moudlator type clock consuming things in the 2.1 milestone, clean this up before we copy it more.

Closes #665