### PR TITLE
The modulatino button doesn't consume press

### DIFF
--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -1217,6 +1217,7 @@ struct ModToggleButton : GlowOverlayHoverButton<rack::widget::Widget>
         if (e.action == GLFW_PRESS)
         {
             armed = true;
+            e.consume(this);
         }
         if (armed && e.action == GLFW_RELEASE)
         {


### PR DESCRIPTION
Modulation arm buttons don't consume press properly. This generally doesn't matter but it means in lock widget mode presisng that button will cause the background to be hit which is a select gesture, improperly.

Closes #676 