### PR TITLE
LFO Randomization Improvements

### DIFF
--- a/src/LFO.h
+++ b/src/LFO.h
@@ -179,8 +179,25 @@ struct LFO : modules::XTModule
             {
                 maxv = Parameter::intScaledToFloat(lt_stepseq, par->val_max.i, par->val_min.i);
             }
-            configParam<modules::SurgeParameterParamQuantity>(
+            auto pq = configParam<modules::SurgeParameterParamQuantity>(
                 p, 0, maxv, par->get_default_value_f01(), par->get_name());
+            if (p == SHAPE)
+            {
+                pq->customRandomize = [this](auto pq) {
+                    auto *par = &lfostorage->rate + paramOffsetByID[pq->paramId];
+                    auto cv = Parameter::intUnscaledFromFloat(pq->getValue(), par->val_max.i,
+                                                              par->val_min.i);
+
+                    if (cv >= lt_stepseq)
+                    {
+                        return;
+                    }
+
+                    auto ncv = rand() % (lt_stepseq);
+                    auto v01 = Parameter::intScaledToFloat(ncv, par->val_max.i, par->val_min.i);
+                    pq->setValue(v01);
+                };
+            }
         }
 
         for (int p = LFO_MOD_PARAM_0; p < UNUSED_PARAM_DEPRECATED; ++p)
@@ -192,9 +209,9 @@ struct LFO : modules::XTModule
         }
 
         configParamNoRand(UNUSED_PARAM_DEPRECATED, 0, 1, 0, "Unused/Deprecated");
-        configParam(DEFORM_TYPE, 0, 4, 0, "Deform Type");
+        configParamNoRand(DEFORM_TYPE, 0, 4, 0, "Deform Type");
         configParamNoRand(WHICH_TEMPOSYNC, 0, 3, 1, "Which Temposync");
-        configParam(RANDOM_PHASE, 0, 1, 0, "Randomize Initial Phase");
+        configParamNoRand(RANDOM_PHASE, 0, 1, 0, "Randomize Initial Phase");
 
         configParamNoRand(TRIGA_TYPE, 0, 3, DEFAULT, "Trigger A");
         configParamNoRand(TRIGB_TYPE, 0, 3, DEFAULT, "Trigger B");
@@ -208,9 +225,10 @@ struct LFO : modules::XTModule
                          std::string("Step Trigger ") + std::to_string(i + 1),
                          {"Off", "A", "B", "A and B"});
         }
-        configParam(STEP_SEQUENCER_START, 0, n_steps - 1, 0, "First Loop Point")->snapEnabled =
+        configParamNoRand(STEP_SEQUENCER_START, 0, n_steps - 1, 0, "First Loop Point")
+            ->snapEnabled = true;
+        configParamNoRand(STEP_SEQUENCER_END, 1, n_steps, n_steps, "Last Loop Point")->snapEnabled =
             true;
-        configParam(STEP_SEQUENCER_END, 1, n_steps, n_steps, "Last Loop Point")->snapEnabled = true;
 
         configParamNoRand(SCALE_RAW_OUTPUTS, 0, 1, 1, "Scale raw outputs by amp?");
         configParamNoRand(NO_TRIG_POLY, 1, 16, 1, "Scale raw outputs by amp?")->snapEnabled = true;

--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -298,6 +298,15 @@ struct SurgeParameterParamQuantity : public rack::engine::ParamQuantity, Calcula
         return par;
     }
 
+    std::function<void(SurgeParameterParamQuantity *)> customRandomize{nullptr};
+    void randomize() override
+    {
+        if (customRandomize)
+            customRandomize(this);
+        else
+            ParamQuantity::randomize();
+    }
+
     virtual void setDisplayValueString(std::string s) override
     {
         auto par = surgepar();


### PR DESCRIPTION
- Step Endpoints non randomizable and a few others too
- The shape is randomizable b ut if you are on step sequencer mode you stay there. Only randomize between the waveforms

Closes #684