### PR TITLE
Final Cardinal related changes

### DIFF
--- a/src/XTModuleWidget.cpp
+++ b/src/XTModuleWidget.cpp
@@ -216,11 +216,13 @@ void XTModuleWidget::appendContextMenu(rack::ui::Menu *menu)
     auto xtm = static_cast<modules::XTModule *>(module);
     appendModuleSpecificMenu(menu);
     menu->addChild(new rack::ui::MenuSeparator);
+#ifndef USING_CARDINAL_NOT_RACK
     auto globalItem =
         rack::createMenuItem("Use Global Style", CHECKMARK(module && xtm->isCoupledToGlobalStyle),
                              [this]() { toggleCoupleToGlobalStyle(); });
     menu->addChild(globalItem);
     menu->addChild(rack::createSubmenuItem("Skin", "", [this](auto *x) { skinMenuFor(x, this); }));
+#endif
     menu->addChild(
         rack::createSubmenuItem("Colors", "", [this](auto *x) { colorsMenuFor(x, this); }));
     menu->addChild(rack::createSubmenuItem("Value Displays", "",

--- a/src/XTStyle.cpp
+++ b/src/XTStyle.cpp
@@ -38,7 +38,11 @@ void XTStyle::initialize()
     }
     if (!fd)
     {
+#ifdef USING_CARDINAL_NOT_RACK
+        setGlobalStyle(rack::settings::darkMode ? DARK : LIGHT);
+#else
         setGlobalStyle(MID);
+#endif
         setGlobalDisplayRegionColor(ORANGE);
         setGlobalModulationColor(BLUE);
         setGlobalControlValueColor(ORANGE);


### PR DESCRIPTION
Sorry I completely forgot about this small set of changes.

for the wavetable path stuff, we force the plugin to have a valid path in Cardinal, otherwise it ends up pointing to build code dir (which even if module does not load files, is still ugly and incorrect).
not sure if this works fine in VCV Rack, but this approach is preferred in Cardinal so that `dataPath` always points somewhere valid.

for the theme stuff, I hide the menu options and let Cardinal handle the theme changes.
this is because Cardinal provides its own `bool rack::settings::darkMode` API for it, which I add support in as many modules as possible.
the result is a single option on the "view" menu that switches all possible modules from dark mode to light mode and vice-versa. surge integrates into this well too.
there is a separate file used in Cardinal to provide the listeners callbacks, not needed to be shipped in surge at all.
