### PR TITLE
Quad LFO and CMake tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ target_compile_options(eurorack PRIVATE -Wno-unused-local-typedefs $<$<PLATFORM_
 target_compile_options(sqlite PRIVATE -Wno-error)
 target_compile_options(sst-plugininfra PRIVATE -Wno-unused-variable)
 target_compile_options(sst-waveshapers INTERFACE -Wno-unused-variable)
+target_compile_options(sst-filters INTERFACE -Wno-unused-variable $<$<CONFIG:Debug>:-Wno-sign-compare>)
 target_compile_options(tinyxml PRIVATE -Wno-implicit-fallthrough -Wno-sign-compare)
 target_compile_options(tuning-library INTERFACE $<$<CXX_COMPILER_ID:GNU>:-Wno-maybe-uninitialized>
                        $<$<PLATFORM_ID:Darwin>:-Wno-unused-private-field>)
@@ -63,7 +64,11 @@ target_compile_options(surge-common PRIVATE -Wno-sign-compare -Wno-ignored-quali
                        $<$<PLATFORM_ID:Darwin>:-Wno-mismatched-tags>
                        $<$<PLATFORM_ID:Darwin>:-Wno-infinite-recursion>)
 
-add_compile_options(-fvisibility=hidden -fvisibility-inlines-hidden)
+add_compile_options(-fvisibility=hidden
+        -fvisibility-inlines-hidden
+        $<$<PLATFORM_ID:Darwin>:-Werror>
+        $<$<PLATFORM_ID:Darwin>:-Wno-unused-command-line-argument>
+        $<$<CONFIG:Debug>:-DSURGEXT_RACK_DEBUG>)
 
 add_library(${PROJECT_NAME} STATIC
         src/Delay.cpp

--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -199,7 +199,12 @@ struct Background : public rack::TransparentWidget, style::StyleParticipant
         : panelName(pn), groupName(grp), title(t)
     {
         box.size = size;
+
         onStyleChanged();
+
+#if SURGEXT_RACK_DEBUG
+        addDebug();
+#endif
     }
 
     void drawStubLayer(NVGcontext *vg)
@@ -268,6 +273,11 @@ struct Background : public rack::TransparentWidget, style::StyleParticipant
         {
             alphaWarning->dirty = true;
         }
+
+        if (debugWarning)
+        {
+            debugWarning->dirty = true;
+        }
     }
 
     BufferedDrawFunctionWidget *alphaWarning{nullptr};
@@ -287,6 +297,25 @@ struct Background : public rack::TransparentWidget, style::StyleParticipant
         nvgText(vg, 1.5, 1.5, "ALPHA", nullptr);
         nvgFillColor(vg, nvgRGB(255, 0, 0));
         nvgText(vg, 1, 1, "ALPHA", nullptr);
+    }
+
+    BufferedDrawFunctionWidget *debugWarning{nullptr};
+    void addDebug()
+    {
+        debugWarning = new BufferedDrawFunctionWidget(rack::Vec(0, 0), box.size,
+                                                      [this](auto vg) { drawDebug(vg); });
+        addChild(debugWarning);
+    }
+    void drawDebug(NVGcontext *vg)
+    {
+        nvgBeginPath(vg);
+        nvgFontFaceId(vg, style()->fontIdBold(vg));
+        nvgFontSize(vg, 18);
+        nvgTextAlign(vg, NVG_ALIGN_TOP | NVG_ALIGN_RIGHT);
+        nvgFillColor(vg, style()->getColor(style::XTStyle::TEXT_LABEL));
+        nvgText(vg, box.size.x - 1.5, 1.5, "DBG", nullptr);
+        nvgFillColor(vg, nvgRGB(0, 0, 255));
+        nvgText(vg, box.size.x - 1, 1, "DBG", nullptr);
     }
 };
 

--- a/src/dsp/SimpleLFO.h
+++ b/src/dsp/SimpleLFO.h
@@ -116,6 +116,14 @@ struct SimpleLFO
         lastDPhase = dPhase;
     }
 
+    inline void freeze()
+    {
+        for (auto &f : outputBlock)
+        {
+            f = lastTarget;
+        }
+    }
+
     inline void process_block(const float r, const float d, const int lshape, bool reverse = false)
     {
         float target{0.f};


### PR DESCRIPTION
1. Return -Werror on Darwin
2. Add a DEBUG flag so I can panel-show debug builds
3. Fix a bug in FREEZE mode with non-constant jumps
4. Make Quad LFO scales by x/ rather than decimal