### PR TITLE
First step towards Wavetable Content Download

### DIFF
--- a/.github/workflows/make-extra-content.yml
+++ b/.github/workflows/make-extra-content.yml
@@ -1,0 +1,42 @@
+name: VCV Rack Code Checks
+on: [push]
+
+env:
+  rack-sdk-version: 2.2.1
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-code-checks:
+    name: code-checks
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Get Rack-SDK
+        run: |
+          pushd $HOME
+          curl -o Rack-SDK.zip https://vcvrack.com/downloads/Rack-SDK-${{ env.rack-sdk-version }}-lin-x64.zip
+          unzip Rack-SDK.zip
+      - name: Run Code Checks
+        run: |
+          cmake -Bbuild -DRACK_SDK_DIR=$HOME/Rack-SDK -DCMAKE_BUILD_TYPE=DEBUG
+          cmake --build build --target xt-rack-extra-content
+      - name: Delete old release assets
+        uses: mknejp/delete-release-assets@v1
+        with:
+          token: ${{ github.token }}
+          tag: Content
+          assets: '*'
+      - name: Upload release assets
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/*ExtraContent.tar.zstd
+          tag: Content
+          file_glob: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,10 @@ file(INSTALL surge/resources/surge-shared/configuration.xml
              res/surge_extra_data/fx_presets
     DESTINATION ${PLUGIN_NAME}/build/surge-data)
 
+file(INSTALL
+        surge/resources/data/wavetables_3rdparty
+        DESTINATION ${PLUGIN_NAME}_ExtraContent)
+
 install(TARGETS ${LIB_NAME} LIBRARY DESTINATION ${PROJECT_BINARY_DIR}/${PLUGIN_NAME} OPTIONAL)
 install(DIRECTORY ${PROJECT_BINARY_DIR}/${PLUGIN_NAME}/ DESTINATION ${PLUGIN_NAME})
 
@@ -152,3 +156,11 @@ add_custom_command(TARGET xt-rack-code-checks
         COMMAND git ls-files -- ${CLANG_FORMAT_GLOBS} | xargs ${CLANG_FORMAT_EXE} --dry-run --Werror
         )
 # }}}
+
+add_custom_target(xt-rack-extra-content)
+add_custom_command(TARGET xt-rack-extra-content
+  POST_BUILD
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMAND tar cf ${PLUGIN_NAME}_ExtraContent.tar ${PLUGIN_NAME}_ExtraContent
+  COMMAND zstd -zf ${PLUGIN_NAME}_ExtraContent.tar
+)


### PR DESCRIPTION
First step in 2.1 of moving the wavetables mostly out of the plugin and into an extra content download.

This doesn't change the .vcvplugin but instead makes a target and action which uploads extra content from head on push. We probably want a version strategy later for this but for now lets see if this works.

Addresses #710