### PR TITLE
Delay Clock didn't get SampleRate

### DIFF
--- a/src/Delay.h
+++ b/src/Delay.h
@@ -330,6 +330,11 @@ struct Delay : modules::XTModule
     }
 
     void readModuleSpecificJson(json_t *modJ) override { clockProc.fromJson(modJ); }
+
+    void moduleSpecificSampleRateChange() override
+    {
+        clockProc.setSampleRate(APP->engine->getSampleRate());
+    }
 };
 } // namespace sst::surgext_rack::delay
 #endif

--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -933,6 +933,8 @@ template <typename T> struct ClockProcessor
 
     inline void process(T *m, int inputId)
     {
+        assert(sampleRate > 100);
+
         if (clockStyle == BPM_VOCT)
         {
             if (!bpmConnected)


### PR DESCRIPTION
this means Delay Clock only works in BPM mode; correct and resulting delay clock now works.

Closes #740