### PR TITLE
Improve Switchable Params; Apply to EGxVCA

### DIFF
--- a/src/EGxVCA.cpp
+++ b/src/EGxVCA.cpp
@@ -185,17 +185,61 @@ EGxVCAWidget::EGxVCAWidget(sst::surgext_rack::egxvca::ui::EGxVCAWidget::M *modul
         {li_t::PORT, "CLOCK", M::CLOCK_IN, col2, row1},
         {li_t::OUT_PORT, "ENV", M::ENV_OUT, col3, row1},
 
-        {li_t::VSLIDER_25, "A", M::EG_A, sliderStart + 1.f * dSlider, rowS},
-        {li_t::VSLIDER_25, "D", M::EG_D, sliderStart + 2.f * dSlider, rowS},
-        {li_t::VSLIDER_25, "S", M::EG_S, sliderStart + 3.f * dSlider, rowS},
-        {li_t::VSLIDER_25, "R", M::EG_R, sliderStart + 4.f * dSlider, rowS},
-
         li_t::createLCDArea(row3 - rack::mm2px(2.5))
     };
     // clang-format on
 
     for (const auto &lay : layout)
     {
+        engine_t::layoutItem(this, lay, "EGxVCA");
+    }
+
+    std::vector<li_t> sliderLayout = {
+        {li_t::VSLIDER_25, "A", M::EG_A, sliderStart + 1.f * dSlider, rowS},
+        {li_t::VSLIDER_25, "D", M::EG_D, sliderStart + 2.f * dSlider, rowS},
+        {li_t::VSLIDER_25, "S", M::EG_S, sliderStart + 3.f * dSlider, rowS},
+        {li_t::VSLIDER_25, "R", M::EG_R, sliderStart + 4.f * dSlider, rowS},
+    };
+
+    int i{0};
+    for (auto &lay : sliderLayout)
+    {
+        lay.dynamicLabel = true;
+        lay.dynLabelFn = [i](modules::XTModule *m) -> std::string {
+            auto mode = 0;
+            if (m)
+                mode = std::round(m->paramQuantities[EGxVCA::ADSR_OR_DAHD]->getValue());
+            if (mode == 0)
+            {
+                switch (i)
+                {
+                case 0:
+                    return "A";
+                case 1:
+                    return "D";
+                case 2:
+                    return "S";
+                case 3:
+                    return "R";
+                }
+            }
+            else
+            {
+                switch (i)
+                {
+                case 0:
+                    return "D";
+                case 1:
+                    return "A";
+                case 2:
+                    return "H";
+                case 3:
+                    return "D";
+                }
+            }
+            return {"ERR"};
+        };
+        i++;
         engine_t::layoutItem(this, lay, "EGxVCA");
     }
 

--- a/src/EGxVCA.h
+++ b/src/EGxVCA.h
@@ -82,6 +82,40 @@ struct EGxVCA : modules::XTModule
 
     modules::ModulationAssistant<EGxVCA, n_mod_params, LEVEL, n_mod_inputs, MOD_INPUT_0> modAssist;
 
+    struct DAHDPQ : modules::CTEnvTimeParamQuantity
+    {
+        std::string getCalculatedName() override
+        {
+            switch (paramId)
+            {
+            case EG_A:
+                return "Delay";
+            case EG_D:
+                return "Attack";
+            case EG_S:
+                return "Hold";
+            case EG_R:
+                return "Release";
+            }
+            return {};
+        }
+    };
+
+    struct SurgeOrTimePQ : modules::TypeSwappingParameterQuantity
+    {
+        SurgeOrTimePQ()
+        {
+            addImplementer<modules::SurgeParameterParamQuantity>(0);
+            addImplementer<DAHDPQ>(1);
+        }
+        int mode() override
+        {
+            if (!module)
+                return 0;
+            return (int)std::round(module->paramQuantities[ADSR_OR_DAHD]->getValue());
+        }
+    };
+
     EGxVCA() : XTModule()
     {
         {
@@ -92,10 +126,10 @@ struct EGxVCA : modules::XTModule
 
         configParam<modules::DecibelParamQuantity>(LEVEL, 0, 2, 1, "Level");
         configParam(PAN, -1, 1, 0, "Pan", "%", 0, 100);
-        configParam<modules::SurgeParameterParamQuantity>(EG_A, 0, 1, 0.1, "Attack");
-        configParam<modules::SurgeParameterParamQuantity>(EG_D, 0, 1, 0.1, "Decay");
-        configParam<modules::SurgeParameterParamQuantity>(EG_S, 0, 1, 0.5, "Sustain");
-        configParam<modules::SurgeParameterParamQuantity>(EG_R, 0, 1, 0.1, "Release");
+        configParam<SurgeOrTimePQ>(EG_A, 0, 1, 0.1, "Attack");
+        configParam<SurgeOrTimePQ>(EG_D, 0, 1, 0.1, "Decay");
+        configParam<SurgeOrTimePQ>(EG_S, 0, 1, 0.5, "Sustain");
+        configParam<SurgeOrTimePQ>(EG_R, 0, 1, 0.1, "Release");
         configSwitch(ANALOG_OR_DIGITAL, 0, 1, 0, "Curve", {"Digital", "Analog"});
         configSwitch(ADSR_OR_DAHD, 0, 1, 0, "Mode", {"ADSR", "DAHD"});
 


### PR DESCRIPTION
1. Have a type switchable param quantity by mode more easily ready
2. Use it to at least morph out the DAHD vs ADSR params in EGxVCA