### PR TITLE
Use cmake built plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ target_compile_options(surge-common PRIVATE -Wno-sign-compare -Wno-ignored-quali
 
 target_compile_options(surge-common PRIVATE $<$<STREQUAL:${CMAKE_OSX_ARCHITECTURES},arm64>:-faligned-allocation>)
 
-add_compile_options(-fvisibility=hidden -fvisibility-inlines-hidden $<$<BOOL:${SURGE_XT_WARNINGS_ARE_ERRORS}>:-Werror>)
+add_compile_options($<$<BOOL:${SURGE_XT_WARNINGS_ARE_ERRORS}>:-Werror>)
 add_compile_definitions($<$<CONFIG:Debug>:SURGEXT_RACK_DEBUG>)
 
 add_library(Surge INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,14 +93,14 @@ target_sources(${RACK_PLUGIN_LIB} PRIVATE
 
 target_link_libraries(${RACK_PLUGIN_LIB} PRIVATE Surge)
 
-file(INSTALL surge/resources/surge-shared/configuration.xml
+file(COPY surge/resources/surge-shared/configuration.xml
              surge/resources/surge-shared/windows.wt
              surge/resources/data/wavetables
              surge/resources/data/fx_presets
              res/surge_extra_data/fx_presets
     DESTINATION ${PLUGIN_NAME}/build/surge-data)
 
-file(INSTALL
+file(COPY
         surge/resources/data/wavetables_3rdparty
         DESTINATION ${PLUGIN_NAME}_ExtraContent)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,8 @@ endif ()
 
 target_link_libraries(Surge INTERFACE ${SURGE_LIBS} ${SURGE_WIN_LIBS})
 
-add_library(${PLUGIN_NAME} STATIC
+target_sources(${RACK_PLUGIN_LIB} PRIVATE
+        src/SurgeXT.cpp
         src/Delay.cpp
         src/DelayLineByFreq.cpp
         src/EGxVCA.cpp
@@ -88,18 +89,9 @@ add_library(${PLUGIN_NAME} STATIC
         src/Waveshaper.cpp
         src/XTModule.cpp
         src/XTModuleWidget.cpp
-        src/XTStyle.cpp
-        )
+        src/XTStyle.cpp)
 
-target_link_libraries(${PLUGIN_NAME} LINK_PUBLIC RackSDK Surge)
-
-target_sources(${RACK_PLUGIN_LIB} PRIVATE src/SurgeXT.cpp)
-target_link_libraries(${RACK_PLUGIN_LIB} PRIVATE ${PLUGIN_NAME})
-
-
-install(TARGETS ${RACK_PLUGIN_LIB} ${PLUGIN_NAME} ${SURGE_LIBS}
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib/static)
+target_link_libraries(${RACK_PLUGIN_LIB} PRIVATE Surge)
 
 file(INSTALL surge/resources/surge-shared/configuration.xml
              surge/resources/surge-shared/windows.wt

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,17 @@ include $(RACK_DIR)/arch.mk
 
 EXTRA_CMAKE :=
 RACK_PLUGIN := plugin.so
+
+ifdef ARCH_WIN
+  RACK_PLUGIN := plugin.dll
+endif
+
 ifdef ARCH_MAC
   EXTRA_CMAKE := -DCMAKE_OSX_ARCHITECTURES="x86_64"
   RACK_PLUGIN := plugin.dylib
   ifdef ARCH_ARM64
     EXTRA_CMAKE := -DCMAKE_OSX_ARCHITECTURES="arm64"
   endif
-endif
-ifdef ARCH_WIN
-  RACK_PLUGIN := plugin.dll
 endif
 
 CMAKE_BUILD ?= dep/cmake-build

--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,36 @@
 RACK_DIR ?= ../..
 include $(RACK_DIR)/arch.mk
 
-SURGE_BLD=dep/surge-build
-libsurge_xt_rack := $(SURGE_BLD)/libSurgeXTRack.a
-
-OBJECTS += $(libsurge_xt_rack)
-
-# Trigger the surge-rack CMake build when running `make dep`
-DEPS += $(libsurge_xt_rack)
-
 EXTRA_CMAKE :=
+RACK_PLUGIN := plugin.so
 ifdef ARCH_MAC
-ifdef ARCH_ARM64
-    EXTRA_CMAKE += -DCMAKE_OSX_ARCHITECTURES="arm64"
-else
-    EXTRA_CMAKE += -DCMAKE_OSX_ARCHITECTURES="x86_64"
+  EXTRA_CMAKE := -DCMAKE_OSX_ARCHITECTURES="x86_64"
+  RACK_PLUGIN := plugin.dylib
+  ifdef ARCH_ARM64
+    EXTRA_CMAKE := -DCMAKE_OSX_ARCHITECTURES="arm64"
+  endif
 endif
-endif
-
-$(libsurge_xt_rack): CMakeLists.txt
-	$(CMAKE) -B $(SURGE_BLD) -DRACK_SDK_DIR=$(RACK_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(SURGE_BLD)/dist $(EXTRA_CMAKE)
-	cmake --build $(SURGE_BLD) -- -j $(shell getconf _NPROCESSORS_ONLN)
-	cmake --install $(SURGE_BLD)
-
-# Add .cpp and .c files to the build
-SOURCES += src/SurgeXT.cpp
-
-FLAGS += -fvisibility=hidden -fvisibility-inlines-hidden -std=c++17
-
-LDFLAGS += -L$(SURGE_BLD)/dist/lib/static -lSurgeXTRack -lsurge-common -ljuce_dsp_rack_sub -ltinyxml -lstrnatcmp \
-           -lsamplerate -lsst-plugininfra -lfmt -lsqlite -leurorack -lairwindows
-
 ifdef ARCH_WIN
-LDFLAGS += -lwinmm -luuid -lwsock32 -lshlwapi -lversion -lwininet -lole32 -lws2_32
-else
-LDFLAGS += -lfilesystem
+  RACK_PLUGIN := plugin.dll
 endif
+
+CMAKE_BUILD=dep/cmake-build
+cmake_rack_plugin := $(CMAKE_BUILD)/$(RACK_PLUGIN)
+
+$(info cmake_rack_plugin target is '$(cmake_rack_plugin)')
+
+# trigger CMake build when running `make dep`
+DEPS += $(cmake_rack_plugin)
+
+$(cmake_rack_plugin): CMakeLists.txt
+	rm -rf $(RACK_PLUGIN)
+	$(CMAKE) -B$(CMAKE_BUILD) -DRACK_SDK_DIR=$(RACK_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(CMAKE_BUILD)/dist $(EXTRA_CMAKE)
+	cmake --build $(CMAKE_BUILD) -- -j $(shell getconf _NPROCESSORS_ONLN)
+	cmake --install $(CMAKE_BUILD)
+	cp -vf $(cmake_rack_plugin) .
 
 
 # Add files to the ZIP package when running `make dist`
-# The compiled plugin is automatically added.
 dist:	build/surge-data res
 
 build/surge-data:
@@ -56,8 +47,6 @@ DISTRIBUTABLES += $(wildcard LICENSE*) res docs patches presets README.md build/
 # Include the VCV plugin Makefile framework
 include $(RACK_DIR)/plugin.mk
 
-# undo the 11-ness
-CXXFLAGS := $(filter-out -std=c++11,$(CXXFLAGS))
 
 COMMUNITY_ISSUE=https://github.com/VCVRack/community/issues/745
 

--- a/Makefile
+++ b/Makefile
@@ -14,24 +14,27 @@ ifdef ARCH_WIN
   RACK_PLUGIN := plugin.dll
 endif
 
-CMAKE_BUILD=dep/cmake-build
+CMAKE_BUILD ?= dep/cmake-build
 cmake_rack_plugin := $(CMAKE_BUILD)/$(RACK_PLUGIN)
 
 $(info cmake_rack_plugin target is '$(cmake_rack_plugin)')
+
+# create empty plugin lib to skip the make target execution
+$(shell touch $(RACK_PLUGIN))
 
 # trigger CMake build when running `make dep`
 DEPS += $(cmake_rack_plugin)
 
 $(cmake_rack_plugin): CMakeLists.txt
-	rm -rf $(RACK_PLUGIN)
-	$(CMAKE) -B$(CMAKE_BUILD) -DRACK_SDK_DIR=$(RACK_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(CMAKE_BUILD)/dist $(EXTRA_CMAKE)
+	$(CMAKE) -B $(CMAKE_BUILD) -DRACK_SDK_DIR=$(RACK_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(CMAKE_BUILD)/dist $(EXTRA_CMAKE)
 	cmake --build $(CMAKE_BUILD) -- -j $(shell getconf _NPROCESSORS_ONLN)
 	cmake --install $(CMAKE_BUILD)
+
+rack_plugin: $(cmake_rack_plugin)
 	cp -vf $(cmake_rack_plugin) .
 
-
 # Add files to the ZIP package when running `make dist`
-dist:	build/surge-data res
+dist: rack_plugin build/surge-data res
 
 build/surge-data:
 	mkdir -p build/surge-data

--- a/README.md
+++ b/README.md
@@ -37,11 +37,17 @@ make install
 ```
 To compile the plugin with CMake for Mac OSX `x86_64` platform append `-DCMAKE_OSX_ARCHITECTURES="x86_64"` to the cmake
 command, to compile for `arm64` platform use `-DCMAKE_OSX_ARCHITECTURES="arm64"`.
-Build with Make (only to create a release build) :
+
+Create a plugin release with Make:
 ```
 export RACK_DIR=location-of-rack-SDK-or-source
 make dep
 make dist
+```
+
+Alternatively create a plugin release with Make and point to an existing cmake build location:
+```
+CMAKE_BUILD=location-of-cmake-build-dir make dist
 ```
 ## License and Copyright
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,7 @@ git clone https://github.com/surge-synthesizer/surge-rack
 cd surge-rack
 git submodule update --init --recursive
 ```
-Build with Make:
-```
-export RACK_DIR=location-of-rack-SDK-or-source
-make dist
-```
-Build directly with CMake:
+Build with CMake:
 ```
 mkdir surge-rack-build
 cd surge-rack-build
@@ -42,7 +37,12 @@ make install
 ```
 To compile the plugin with CMake for Mac OSX `x86_64` platform append `-DCMAKE_OSX_ARCHITECTURES="x86_64"` to the cmake
 command, to compile for `arm64` platform use `-DCMAKE_OSX_ARCHITECTURES="arm64"`.
-
+Build with Make (only to create a release build) :
+```
+export RACK_DIR=location-of-rack-SDK-or-source
+make dep
+make dist
+```
 ## License and Copyright
 
 This software is licensed under the Gnu General Public License v3 or later.

--- a/RackSDK.cmake
+++ b/RackSDK.cmake
@@ -92,7 +92,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   target_compile_options(RackSDK INTERFACE -Wl,-rpath=/tmp/Rack2)
 endif ()
 
-target_link_libraries(${RACK_PLUGIN_LIB} PRIVATE ${RackSDK})
+target_link_libraries(${RACK_PLUGIN_LIB} PRIVATE RackSDK)
 
 install(TARGETS ${RACK_PLUGIN_LIB} LIBRARY DESTINATION ${PROJECT_BINARY_DIR}/${PLUGIN_NAME} OPTIONAL)
 install(DIRECTORY ${PROJECT_BINARY_DIR}/${PLUGIN_NAME}/ DESTINATION ${PLUGIN_NAME})
@@ -100,9 +100,8 @@ file(INSTALL ${PLUGIN_DISTRIBUTABLES} DESTINATION ${PLUGIN_NAME})
 
 # A quick installation target to copy the plugin library and plugin.json into VCV Rack plugin folder for development.
 # CMAKE_INSTALL_PREFIX needs to point to the VCV Rack plugin folder in user documents.
-add_custom_target(${PROJECT_NAME}_quick_install
+add_custom_target(${RACK_PLUGIN_LIB}_quick_install
         COMMAND cmake -E copy $<TARGET_FILE:${RACK_PLUGIN_LIB}> ${CMAKE_INSTALL_PREFIX}/${PLUGIN_NAME}
         COMMAND cmake -E copy ${CMAKE_SOURCE_DIR}/plugin.json ${CMAKE_INSTALL_PREFIX}/${PLUGIN_NAME}
         )
-add_dependencies(${PROJECT_NAME}_quick_install ${PLUGIN_NAME})
-add_dependencies(${PROJECT_NAME}_quick_install ${RACK_PLUGIN_LIB})
+add_dependencies(${RACK_PLUGIN_LIB}_quick_install ${RACK_PLUGIN_LIB})

--- a/RackSDK.cmake
+++ b/RackSDK.cmake
@@ -40,9 +40,10 @@ add_compile_options(-fPIC)
 # Debugger symbols. These are removed with `strip`.
 add_compile_options(-g)
 # Optimization
-if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   message(STATUS "Skipping Optimizations for Debug Build")
 else()
+  message(STATUS "Skipping Optimizations for Debug Build")
   add_compile_options(-O3 -funsafe-math-optimizations -fno-omit-frame-pointer)
 endif()
 # Warnings

--- a/RackSDK.cmake
+++ b/RackSDK.cmake
@@ -43,7 +43,7 @@ add_compile_options(-O3 -funsafe-math-optimizations -fno-omit-frame-pointer)
 # Warnings
 add_compile_options(-Wall -Wextra -Wno-unused-parameter)
 # C++ standard
-if (${CMAKE_CXX_STANDARD} AND (${CMAKE_CXX_STANDARD} GREATER_EQUAL 11))
+if (DEFINED CMAKE_CXX_STANDARD)
   message(STATUS "Retaining CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
 else()
   set(CMAKE_CXX_STANDARD 11)

--- a/RackSDK.cmake
+++ b/RackSDK.cmake
@@ -21,6 +21,12 @@ if ("${ADDITIONAL_PLUGIN_DISTRIBUTABLES}" STREQUAL "")
    folder add ADDITIONAL_PLUGIN_DISTRIBUTABLES variable to the project CMakeLists.txt before including RackSDK.cmake.")
 endif ()
 
+add_compile_options(
+        -fvisibility=hidden
+        # Inlines visibility is only relevant with C++
+        $<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>
+)
+
 # Do not change the RACK_PLUGIN_LIB!
 set(RACK_PLUGIN_LIB plugin)
 
@@ -39,7 +45,11 @@ add_compile_options(-fPIC)
 # Debugger symbols. These are removed with `strip`.
 add_compile_options(-g)
 # Optimization
-add_compile_options(-O3 -funsafe-math-optimizations -fno-omit-frame-pointer)
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+  message(STATUS "Skipping Optimizations for Debug Build")
+else()
+  add_compile_options(-O3 -funsafe-math-optimizations -fno-omit-frame-pointer)
+endif()
 # Warnings
 add_compile_options(-Wall -Wextra -Wno-unused-parameter)
 # C++ standard

--- a/RackSDK.cmake
+++ b/RackSDK.cmake
@@ -21,12 +21,6 @@ if ("${ADDITIONAL_PLUGIN_DISTRIBUTABLES}" STREQUAL "")
    folder add ADDITIONAL_PLUGIN_DISTRIBUTABLES variable to the project CMakeLists.txt before including RackSDK.cmake.")
 endif ()
 
-add_compile_options(
-        -fvisibility=hidden
-        # Inlines visibility is only relevant with C++
-        $<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>
-)
-
 # Do not change the RACK_PLUGIN_LIB!
 set(RACK_PLUGIN_LIB plugin)
 
@@ -35,6 +29,7 @@ set(PLUGIN_DISTRIBUTABLES plugin.json res ${LICENSE} ${ADDITIONAL_PLUGIN_DISTRIB
 
 message(STATUS "PLUGIN_DISTRIBUTABLES: ${PLUGIN_DISTRIBUTABLES}")
 
+add_compile_options(-fvisibility=hidden $<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>)
 # This is needed for Rack for DAWs.
 # Static libs don't usually compiled with -fPIC, but since we're including them in a shared library, it's needed.
 add_compile_options(-fPIC)

--- a/RackSDK.cmake
+++ b/RackSDK.cmake
@@ -106,7 +106,7 @@ target_link_libraries(${RACK_PLUGIN_LIB} PRIVATE RackSDK)
 
 install(TARGETS ${RACK_PLUGIN_LIB} LIBRARY DESTINATION ${PROJECT_BINARY_DIR}/${PLUGIN_NAME} OPTIONAL)
 install(DIRECTORY ${PROJECT_BINARY_DIR}/${PLUGIN_NAME}/ DESTINATION ${PLUGIN_NAME})
-file(INSTALL ${PLUGIN_DISTRIBUTABLES} DESTINATION ${PLUGIN_NAME})
+file(COPY ${PLUGIN_DISTRIBUTABLES} DESTINATION ${PLUGIN_NAME})
 
 # A quick installation target to copy the plugin library and plugin.json into VCV Rack plugin folder for development.
 # CMAKE_INSTALL_PREFIX needs to point to the VCV Rack plugin folder in user documents.


### PR DESCRIPTION
This is my proposal to build the plugin dist just with CMake and not rebuild it again with Make build.

It basically works, but I'm not sure if this approach is OK.
The only weird thing is that at first call Make creates a "empty plugin" (enforced by `all` target), but it gets immediately overwritten with the cmake built plugin (copied from cmake build), so it doesn't matter.
The trick is to copy the CMake built plugin into the project dir so the dist target is using it and Make doesn't need to build the plugin completely again.

With this it is possible to get rid of all the extra build instructions in the Makefile and have now a generic working Makefile that can just be thrown in a CMake based Rack plugin project for building a proper release. The only thing required to set is the `DISTRIBUTABLES` values.

It is also possible to point Make to an existing CMake build dir by setting `CMAKE_BUILD` variable from outside, so it just uses the plugin from there or it gets build in that folder instead of inside `dep` folder.

Maybe someone with more Make expertise should have a look here as well.