### PR TITLE
Don't allow double downloads

### DIFF
--- a/src/VCO.h
+++ b/src/VCO.h
@@ -709,8 +709,7 @@ template <int oscType> struct VCO : public modules::XTModule
     std::array<std::unique_ptr<sst::filters::HalfRate::HalfRateFilter>, MAX_POLY> halfbandOUT;
     sst::filters::HalfRate::HalfRateFilter halfbandIN;
     float audioInBuffer[BLOCK_SIZE_OS];
-    std::atomic<bool> forceRefreshWT{false}, downloadingContent{false};
-    float contentProgress{0};
+    std::atomic<bool> forceRefreshWT{false};
 
     rack::dsp::SchmittTrigger reTrigger[MAX_POLY];
 


### PR DESCRIPTION
Double downloads conflict horribly. Move the is-download indicator from module-local to process-static, deactivate the menu when downlaods are ongoing, don't laucnh a new one if an old one is on, etc..

Closes #747