### PR TITLE
Updare VCO Modulation Tooltip Display

### DIFF
--- a/src/QuadLFO.h
+++ b/src/QuadLFO.h
@@ -620,7 +620,7 @@ struct QuadLFO : modules::XTModule
             configParam<RateQuantity>(RATE_0 + i, 0, 1, defaultRate0);
             configParam<DeformQuantity>(DEFORM_0 + i, -1, 1, 0);
             configSwitch(SHAPE_0 + i, 0, 7, 0, "Shape",
-                         {"Sine", "Ramp", "Downward Ramp", "Triangle", "Pulse", "Randon", "S&H",
+                         {"Sine", "Ramp", "Downward Ramp", "Triangle", "Pulse", "Random", "S&H",
                           "Random Trigger"});
             configSwitch(BIPOLAR_0 + i, 0, 1, 1, "Bipolar", {"Uni", "Bi"});
         }
@@ -1124,7 +1124,7 @@ struct QuadLFO : modules::XTModule
             {
                 processors[i][c]->setAmplitude(1.0);
             }
-            paramQuantities[RATE_0 + i]->defaultValue = RateQuantity::independentRateScale(0.5);
+            paramQuantities[RATE_0 + i]->defaultValue = RateQuantity::independentRateScaleInv(0);
         }
         switch (ip)
         {

--- a/src/VCO.h
+++ b/src/VCO.h
@@ -552,19 +552,9 @@ template <int oscType> struct VCO : public modules::XTModule
             VCOConfig<oscType>::processVCOSpecificParameters(this);
             reInitEveryOSC = reInitEveryOSC || VCOConfig<oscType>::getVCOSpecificReInit(this);
 
-            if (animateDisplayFromMod)
+            for (int i = 0; i < n_osc_params; ++i)
             {
-                for (int i = 0; i < n_osc_params; ++i)
-                {
-                    oscstorage_display->p[i].set_value_f01(modAssist.values[i + 1][0]);
-                }
-            }
-            else
-            {
-                for (int i = 0; i < n_osc_params; ++i)
-                {
-                    oscstorage_display->p[i].set_value_f01(modAssist.basevalues[i + 1]);
-                }
+                oscstorage_display->p[i].set_value_f01(modAssist.basevalues[i + 1]);
             }
 
             // This is super gross and inefficient. Think about all of this


### PR DESCRIPTION
Modulation tooltip was based on oscstorage_display which was modulated to animate the display so it was totally wacky. Change it so the display has the base values and modify through the tp[] structure etc... so the animation continues but the tooltips reflect base properly. Closes #636

Also set defaults for rate on QuadLFO propelry and fix a typo there in a dropdown