### PR TITLE
Workaround for mingw LTO builds

### DIFF
--- a/src/XTModuleWidget.cpp
+++ b/src/XTModuleWidget.cpp
@@ -18,6 +18,11 @@
 namespace sst::surgext_rack::widgets
 {
 
+/* fix mingw LTO build */
+Label::~Label() {}
+ModRingKnob::~ModRingKnob() {}
+VerticalSliderModulator::~VerticalSliderModulator() {}
+
 /*
 ** These are internal only classes
 */

--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -123,6 +123,7 @@ struct Label : BufferedDrawFunctionWidget, style::StyleParticipant
         box.pos = pos;
         box.size = sz;
     }
+    ~Label();
 
     modules::XTModule *module{nullptr};
     std::function<std::string(modules::XTModule *m)> dynamicLabel{};
@@ -668,6 +669,7 @@ struct ModRingKnob : rack::app::Knob, style::StyleParticipant, HasBDW
     float radius{1};
 
     ModRingKnob() { box.size = rack::Vec(45, 45); }
+    ~ModRingKnob();
 
     void drawWidget(NVGcontext *vg)
     {
@@ -2355,6 +2357,7 @@ struct VerticalSliderModulator : rack::SliderKnob, style::StyleParticipant, HasB
     int modIndex{0};
 
     VerticalSliderModulator() { box.size = rack::Vec(45, 45); }
+    ~VerticalSliderModulator();
 
     void drawWidget(NVGcontext *vg)
     {


### PR DESCRIPTION
This is a kinda ugly one, but needed in order to build with LTO on mingw.
I can't really explain it, unpatched code is valid, so this just seems to be a compiler bug.

build error log example:
```
Creating LV2 plugin for Cardinal
/usr/bin/i686-w64-mingw32-ld: VCO.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev[__ZThn80_N3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev]+0x0): multiple definition of `sst::surgext_rack::widgets::VerticalSliderModulator::~VerticalSliderModulator()'; Delay.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev[__ZThn92_N3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev]+0x0): first defined here
/usr/bin/i686-w64-mingw32-ld: VCO.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev[__ZThn80_N3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev]+0x0): multiple definition of `non-virtual thunk to sst::surgext_rack::widgets::VerticalSliderModulator::~VerticalSliderModulator()'; Delay.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev[__ZThn92_N3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev]+0x0): first defined here
/usr/bin/i686-w64-mingw32-ld: VCO.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev[__ZThn80_N3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev]+0x0): multiple definition of `non-virtual thunk to sst::surgext_rack::widgets::VerticalSliderModulator::~VerticalSliderModulator()'; Delay.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev[__ZThn92_N3sst12surgext_rack7widgets23VerticalSliderModulatorD1Ev]+0x0): first defined here
/usr/bin/i686-w64-mingw32-ld: VCO.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev[__ZThn80_N3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev]+0x0): multiple definition of `sst::surgext_rack::widgets::VerticalSliderModulator::~VerticalSliderModulator()'; Delay.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev[__ZThn92_N3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev]+0x0): first defined here
/usr/bin/i686-w64-mingw32-ld: VCO.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev[__ZThn80_N3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev]+0x0): multiple definition of `non-virtual thunk to sst::surgext_rack::widgets::VerticalSliderModulator::~VerticalSliderModulator()'; Delay.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev[__ZThn92_N3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev]+0x0): first defined here
/usr/bin/i686-w64-mingw32-ld: VCO.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev[__ZThn80_N3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev]+0x0): multiple definition of `non-virtual thunk to sst::surgext_rack::widgets::VerticalSliderModulator::~VerticalSliderModulator()'; Delay.cpp.o (symbol from plugin):(.gnu.linkonce.t._ZN3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev[__ZThn92_N3sst12surgext_rack7widgets23VerticalSliderModulatorD0Ev]+0x0): first defined here
```

It is not intrusive, just a bit annoying. But easy to workaround, already used to it by now..
