### PR TITLE
Alias Modes for Memory Locations supressed

### DIFF
--- a/src/FX.h
+++ b/src/FX.h
@@ -194,7 +194,7 @@ template <int fxType> struct FX : modules::XTModule
 
     void setupSurge()
     {
-        setupSurgeCommon(NUM_PARAMS, true); // get those presets. FIXME skip wt later
+        setupSurgeCommon(NUM_PARAMS, false);
 
         fxstorage = &(storage->getPatch().fx[0]);
         fxstorage->type.val.i = fxType;

--- a/src/VCO.cpp
+++ b/src/VCO.cpp
@@ -1313,6 +1313,8 @@ VCOWidget<oscType>::VCOWidget(VCOWidget<oscType>::M *module) : XTModuleWidget()
             int step{1};
             for (int i = surgePar.val_min.i; i <= surgePar.val_max.i; i += step)
             {
+                if (!VCOConfig<oscType>::showRightMenuChoice(i))
+                    continue;
                 char txt[256];
                 auto fv = Parameter::intScaledToFloat(i, surgePar.val_max.i, surgePar.val_min.i);
                 surgePar.get_display(txt, true, fv);

--- a/src/VCO.h
+++ b/src/VCO.h
@@ -48,6 +48,7 @@ template <int oscType> struct VCOConfig
     {
         return [](auto &s) { return s; };
     }
+    static bool showRightMenuChoice(int choiceIndex) { return true; }
 
     static void oscillatorSpecificSetup(VCO<oscType> *) {}
     static void processVCOSpecificParameters(VCO<oscType> *m) {}


### PR DESCRIPTION
- The memory locations don't make sense in rack
- Supress them at a UI level and if they hit the engine flip em off there too

Closes #706