### PR TITLE
Fix a Twist SampleRate Change problem

### DIFF
--- a/src/VCO.h
+++ b/src/VCO.h
@@ -371,19 +371,7 @@ template <int oscType> struct VCO : public modules::XTModule
     static constexpr int n_state_slots{4};
     int intStateForConfig[n_state_slots];
 
-    void moduleSpecificSampleRateChange() override
-    {
-        forceRespawnDueToExternality = true;
-        if (VCOConfig<oscType>::recreateOnSampleRateChange())
-        {
-            for (int i = 0; i < MAX_POLY; ++i)
-            {
-                if (surge_osc[i])
-                    surge_osc[i]->~Oscillator();
-                surge_osc[i] = nullptr;
-            }
-        }
-    }
+    void moduleSpecificSampleRateChange() override { forceRespawnDueToSampleRate = true; }
 
     struct WavetableMessage
     {
@@ -414,7 +402,7 @@ template <int oscType> struct VCO : public modules::XTModule
 
     std::array<int, MAX_POLY> lastUnison{-1};
     int lastNChan{-1};
-    bool forceRespawnDueToExternality = false;
+    bool forceRespawnDueToSampleRate = false;
     static constexpr int checkWaveTableEvery{512};
     int checkedWaveTable{checkWaveTableEvery};
     static constexpr int calcModMatrixEvery{256};
@@ -492,7 +480,20 @@ template <int oscType> struct VCO : public modules::XTModule
             }
         }
 
-        if (nChan != lastNChan || forceRespawnDueToExternality)
+        if constexpr (VCOConfig<oscType>::recreateOnSampleRateChange())
+        {
+            if (forceRespawnDueToSampleRate)
+            {
+                for (int i = 0; i < MAX_POLY; ++i)
+                {
+                    if (surge_osc[i])
+                        surge_osc[i]->~Oscillator();
+                    surge_osc[i] = nullptr;
+                }
+            }
+        }
+
+        if (nChan != lastNChan || forceRespawnDueToSampleRate)
         {
             lastNChan = nChan;
             // Set up unmodulated values
@@ -521,7 +522,7 @@ template <int oscType> struct VCO : public modules::XTModule
                     surge_osc[c]->init(pitch0);
                 }
             }
-            forceRespawnDueToExternality = false;
+            forceRespawnDueToSampleRate = false;
             processPosition = BLOCK_SIZE + 1;
         }
 

--- a/src/vcoconfig/String.h
+++ b/src/vcoconfig/String.h
@@ -85,13 +85,13 @@ template <> void VCOConfig<ot_string>::processVCOSpecificParameters(VCO<ot_strin
         {
             p->deform_type =
                 (p->deform_type & ~StringOscillator::os_all) | StringOscillator::os_twox;
-            m->forceRespawnDueToExternality = true;
+            m->forceRespawnDueToSampleRate = true;
         }
         else if (!l0 && dt != StringOscillator::os_onex)
         {
             p->deform_type =
                 (p->deform_type & ~StringOscillator::os_all) | StringOscillator::os_onex;
-            m->forceRespawnDueToExternality = true;
+            m->forceRespawnDueToSampleRate = true;
         }
     }
 }

--- a/src/vcoconfig/Twist.h
+++ b/src/vcoconfig/Twist.h
@@ -206,6 +206,7 @@ template <> VCOConfig<ot_twist>::layout_t VCOConfig<ot_twist>::getLayout()
     };
 }
 
+template <> constexpr bool VCOConfig<ot_twist>::recreateOnSampleRateChange() { return true; }
 template <> int VCOConfig<ot_twist>::rightMenuParamId() { return 0; }
 template <> std::string VCOConfig<ot_twist>::retriggerLabel() { return "TRIG"; }
 


### PR DESCRIPTION
If you changed a sample rate in a running session, Twist didn't re-initialize properly.

Closes #767