### PR TITLE
Update Mac build for 2.2.2

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -90,7 +90,7 @@ jobs:
           export CROSS_COMPILE=$CROSS_COMPILE_TARGET_${{ matrix.platform }}
           make dep
           make dist
-          echo "Plugin architecture '$(lipo -archs plugin.dylib)'"
+          echo "Plugin architecture '$(lipo -archs plugin*.dylib)'"
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 standalone/bld/*
 dist/
 plugin.dylib
+plugin-arm64.dylib
 plugin.so
 plugin.dll
 standalone/exe_*

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ ifdef ARCH_MAC
   RACK_PLUGIN := plugin.dylib
   ifdef ARCH_ARM64
     EXTRA_CMAKE := -DCMAKE_OSX_ARCHITECTURES="arm64"
+    RACK_PLUGIN := plugin-arm64.dylib
   endif
 endif
 

--- a/RackSDK.cmake
+++ b/RackSDK.cmake
@@ -22,7 +22,15 @@ if ("${ADDITIONAL_PLUGIN_DISTRIBUTABLES}" STREQUAL "")
 endif ()
 
 # Do not change the RACK_PLUGIN_LIB!
-set(RACK_PLUGIN_LIB plugin)
+if (APPLE)
+  if (${CMAKE_OSX_ARCHITECTURES} MATCHES "arm64")
+    set(RACK_PLUGIN_LIB plugin-arm64)
+  else()
+    set(RACK_PLUGIN_LIB plugin)
+  endif()
+else()
+  set(RACK_PLUGIN_LIB plugin)
+endif()
 
 file(GLOB LICENSE LICENSE*)
 set(PLUGIN_DISTRIBUTABLES plugin.json res ${LICENSE} ${ADDITIONAL_PLUGIN_DISTRIBUTABLES})
@@ -104,10 +112,17 @@ install(TARGETS ${RACK_PLUGIN_LIB} LIBRARY DESTINATION ${PROJECT_BINARY_DIR}/${P
 install(DIRECTORY ${PROJECT_BINARY_DIR}/${PLUGIN_NAME}/ DESTINATION ${PLUGIN_NAME})
 file(COPY ${PLUGIN_DISTRIBUTABLES} DESTINATION ${PLUGIN_NAME})
 
+# Since the name of RACK_PLUGIN_LIB is no longer stable in SDK 2.2.1 add a stable
+# named target
+set(RACK_BUILD_TARGET build_plugin)
+add_custom_target(${RACK_BUILD_TARGET})
+add_dependencies(${RACK_BUILD_TARGET} ${RACK_PLUGIN_LIB})
+
 # A quick installation target to copy the plugin library and plugin.json into VCV Rack plugin folder for development.
 # CMAKE_INSTALL_PREFIX needs to point to the VCV Rack plugin folder in user documents.
-add_custom_target(${RACK_PLUGIN_LIB}_quick_install
+set(RACK_QUICK_INSTALL ${RACK_BUILD_TARGET}_quick_install)
+add_custom_target(${RACK_QUICK_INSTALL}
         COMMAND cmake -E copy $<TARGET_FILE:${RACK_PLUGIN_LIB}> ${CMAKE_INSTALL_PREFIX}/${PLUGIN_NAME}
         COMMAND cmake -E copy ${CMAKE_SOURCE_DIR}/plugin.json ${CMAKE_INSTALL_PREFIX}/${PLUGIN_NAME}
         )
-add_dependencies(${RACK_PLUGIN_LIB}_quick_install ${RACK_PLUGIN_LIB})
+add_dependencies(${RACK_QUICK_INSTALL} ${RACK_BUILD_TARGET})


### PR DESCRIPTION
SDK 2.2.2 changes target name to plugin-arm64 so:

1. Make that switch on ${RACK_PLUGIN_LIB}
2. Since RPL is now no longer a stable name name a RACK_BUILD_TARGET dummy target called 'build_plugin' and modify quick install rule accordingly
3. Update the Makefile for new name
4. Update GHWF for 2.2.2 for mac