### PR TITLE
Exciter NaN / Overload avoifdance

### DIFF
--- a/src/fxconfig/Exciter.h
+++ b/src/fxconfig/Exciter.h
@@ -45,5 +45,12 @@ template <> FXConfig<fxt_exciter>::layout_t FXConfig<fxt_exciter>::getLayout()
         // clang-format on
     };
 }
+
+// The exciter is super input sensitive to overflows and can generate big spikes if it
+// gets them. In the VST the signal is attenuated by 6db by the half rate filter so take
+// most of that out here (I don't want to go all the way to a half because...) and add
+// a softclip to make sure outbound spikes dont emerge.
+template <> constexpr float FXConfig<fxt_exciter>::rescaleInputFactor() { return 0.666666f; }
+template <> constexpr bool FXConfig<fxt_exciter>::softclipOutput() { return true; }
 } // namespace sst::surgext_rack::fx
 #endif // SURGEXT_RACK_FX_ROTARYSPEAKER_H


### PR DESCRIPTION
The exciter effect is very succepitlbe to levels and in a chain would NaN out. Fix this with two things

1. Scale the inputs and outputs to make the signal we send a bit less 'hot'. This is similar to the attenuatino of the half band filter in the VST which the effect is callibrated for
2. Softclip the outputs in case it does get spiky so we don't send overflow down the pipe
3. Add these as config options which are constexpr off for everyone else

Closes #749