### PR TITLE
Move to json_object_set_new consistently

### DIFF
--- a/src/FX.h
+++ b/src/FX.h
@@ -762,9 +762,10 @@ template <int fxType> struct FX : modules::XTModule
         {
             if (loadedPreset >= 0)
             {
-                json_object_set(fx, "loadedPreset", json_integer(loadedPreset));
-                json_object_set(fx, "presetName", json_string(presets[loadedPreset].name.c_str()));
-                json_object_set(fx, "presetIsDirty", json_boolean(presetIsDirty));
+                json_object_set_new(fx, "loadedPreset", json_integer(loadedPreset));
+                json_object_set_new(fx, "presetName",
+                                    json_string(presets[loadedPreset].name.c_str()));
+                json_object_set_new(fx, "presetIsDirty", json_boolean(presetIsDirty));
             }
         }
         if (FXConfig<fxType>::usesClock())
@@ -774,7 +775,7 @@ template <int fxType> struct FX : modules::XTModule
 
         if (FXConfig<fxType>::allowsPolyphony())
         {
-            json_object_set(fx, "polyphonicMode", json_boolean(polyphonicMode));
+            json_object_set_new(fx, "polyphonicMode", json_boolean(polyphonicMode));
         }
         return fx;
     }

--- a/src/LFO.h
+++ b/src/LFO.h
@@ -739,8 +739,8 @@ struct LFO : modules::XTModule
     {
         auto fx = json_object();
         clockProc.toJson(fx);
-        json_object_set(fx, "retriggerFromZero", json_boolean(retriggerFromZero));
-        json_object_set(fx, "onepoleFactor", json_real(onepoleFactor));
+        json_object_set_new(fx, "retriggerFromZero", json_boolean(retriggerFromZero));
+        json_object_set_new(fx, "onepoleFactor", json_real(onepoleFactor));
         return fx;
     }
 

--- a/src/Mixer.h
+++ b/src/Mixer.h
@@ -400,7 +400,7 @@ struct Mixer : modules::XTModule
     json_t *makeModuleSpecificJson() override
     {
         auto vco = json_object();
-        json_object_set(vco, "vuChannel", json_integer(vuChannel));
+        json_object_set_new(vco, "vuChannel", json_integer(vuChannel));
         return vco;
     }
     void readModuleSpecificJson(json_t *modJ) override

--- a/src/QuadAD.h
+++ b/src/QuadAD.h
@@ -431,7 +431,7 @@ struct QuadAD : modules::XTModule
     json_t *makeModuleSpecificJson() override
     {
         auto qv = json_object();
-        json_object_set(qv, "attackFromZero", json_boolean(attackFromZero));
+        json_object_set_new(qv, "attackFromZero", json_boolean(attackFromZero));
         return qv;
     }
 

--- a/src/QuadLFO.h
+++ b/src/QuadLFO.h
@@ -1240,7 +1240,7 @@ struct QuadLFO : modules::XTModule
         auto vc = json_object();
 
         clockProc.toJson(vc);
-        json_object_set(vc, "forcePolyphony", json_integer(forcePolyphony));
+        json_object_set_new(vc, "forcePolyphony", json_integer(forcePolyphony));
 
         return vc;
     }

--- a/src/VCO.h
+++ b/src/VCO.h
@@ -744,14 +744,15 @@ template <int oscType> struct VCO : public modules::XTModule
         if (VCOConfig<oscType>::requiresWavetables() && wavetableCount > 0)
         {
             auto *wtT = json_object();
-            json_object_set(wtT, "draw3D", json_boolean(draw3DWavetable));
+            json_object_set_new(wtT, "draw3D", json_boolean(draw3DWavetable));
 
-            json_object_set(wtT, "display_name", json_string(oscstorage->wavetable_display_name));
+            json_object_set_new(wtT, "display_name",
+                                json_string(oscstorage->wavetable_display_name));
 
             auto &wt = oscstorage->wt;
-            json_object_set(wtT, "n_tables", json_integer(wt.n_tables));
-            json_object_set(wtT, "n_samples", json_integer(wt.size));
-            json_object_set(wtT, "flags", json_integer(wt.flags));
+            json_object_set_new(wtT, "n_tables", json_integer(wt.n_tables));
+            json_object_set_new(wtT, "n_samples", json_integer(wt.size));
+            json_object_set_new(wtT, "flags", json_integer(wt.flags));
 
             wt_header wth;
             memset(wth.tag, 0, 4);
@@ -774,13 +775,14 @@ template <int oscType> struct VCO : public modules::XTModule
             }
             auto b64 = rack::string::toBase64(odata, wtsize);
             delete[] odata;
-            json_object_set(wtT, "data", json_string(b64.c_str()));
-            json_object_set(vco, "wavetable", wtT);
+            json_object_set_new(wtT, "data", json_string(b64.c_str()));
+            json_object_set_new(vco, "wavetable", wtT);
+            wtT = nullptr;
         }
 
-        json_object_set(vco, "halfbandM", json_integer(halfbandM));
-        json_object_set(vco, "halfbandSteep", json_boolean(halfbandSteep));
-        json_object_set(vco, "doDCBlock", json_boolean(doDCBlock));
+        json_object_set_new(vco, "halfbandM", json_integer(halfbandM));
+        json_object_set_new(vco, "halfbandSteep", json_boolean(halfbandSteep));
+        json_object_set_new(vco, "doDCBlock", json_boolean(doDCBlock));
         return vco;
     }
     void readModuleSpecificJson(json_t *modJ) override

--- a/src/Waveshaper.h
+++ b/src/Waveshaper.h
@@ -569,7 +569,7 @@ struct Waveshaper : public modules::XTModule
     json_t *makeModuleSpecificJson() override
     {
         auto ws = json_object();
-        json_object_set(ws, "doDCBlock", json_boolean(doDCBlock));
+        json_object_set_new(ws, "doDCBlock", json_boolean(doDCBlock));
         return ws;
     }
 

--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -238,11 +238,13 @@ struct XTModule : public rack::Module
         json_t *rootJ = json_object();
         if (commonJ)
         {
-            json_object_set(rootJ, "xtshared", commonJ);
+            json_object_set_new(rootJ, "xtshared", commonJ);
+            commonJ = nullptr;
         }
         if (moduleSpecificJ)
         {
-            json_object_set(rootJ, "modulespecific", moduleSpecificJ);
+            json_object_set_new(rootJ, "modulespecific", moduleSpecificJ);
+            moduleSpecificJ = nullptr;
         }
         return rootJ;
     }
@@ -1004,7 +1006,7 @@ template <typename T> struct ClockProcessor
 
     void toJson(json_t *onto)
     {
-        json_object_set(onto, "clockStyle", json_integer((int)clockStyle));
+        json_object_set_new(onto, "clockStyle", json_integer((int)clockStyle));
     }
 
     void fromJson(json_t *modJ)


### PR DESCRIPTION
Closes #817. Tested by running valgrind linux and stressing it on macOS.