### PR TITLE
Don't double-show 2.0.3 and extra wavetables

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,17 @@
 # Surge XT VCV Modules Changelog
 
-## 2.1 - In Beta Now (As of Jan 11, 2023 / 4d2133d)
+## 2.1.1 - February 2023
+
+2.1.1 provides a few small bugfixes. 
+
+- Supress some memory leaks in 2.1 due to mis-using `json_set_object` vs
+  `json_set_object_new`. This leak motivated the point release even
+  though the memory leaked was small.
+- EGxVCA UI tweaks for control positions, gate time drawing, and labels
+- If you have both 2.0.3 and extra wavetables installed, only scan the
+  'extra' downloads copy
+
+## 2.1 - Januar 2023
 
 - New Modules
     - *EGxVCA* - a combined ADSR or DAHD envelope with a panning stereo VCA

--- a/src/VCO.h
+++ b/src/VCO.h
@@ -430,8 +430,8 @@ template <int oscType> struct VCO : public modules::XTModule
         }
         else
         {
-            strncpy(oscstorage->wt.queue_filename, msg.filename, 256);
-            strncpy(oscstorage_display->wt.queue_filename, msg.filename, 256);
+            oscstorage->wt.queue_filename = msg.filename;
+            oscstorage_display->wt.queue_filename = msg.filename;
             oscstorage->wt.frame_size_if_absent = msg.defaultSize;
             oscstorage_display->wt.frame_size_if_absent = msg.defaultSize;
 
@@ -747,7 +747,7 @@ template <int oscType> struct VCO : public modules::XTModule
             json_object_set_new(wtT, "draw3D", json_boolean(draw3DWavetable));
 
             json_object_set_new(wtT, "display_name",
-                                json_string(oscstorage->wavetable_display_name));
+                                json_string(oscstorage->wavetable_display_name.c_str()));
 
             auto &wt = oscstorage->wt;
             json_object_set_new(wtT, "n_tables", json_integer(wt.n_tables));
@@ -834,10 +834,10 @@ template <int oscType> struct VCO : public modules::XTModule
                 }
 
                 oscstorage->wt.current_id = supposedIdx;
-                strncpy(oscstorage->wavetable_display_name, dname.c_str(), 255);
+                oscstorage->wavetable_display_name = dname;
 
                 oscstorage_display->wt.current_id = supposedIdx;
-                strncpy(oscstorage_display->wavetable_display_name, dname.c_str(), 255);
+                oscstorage_display->wavetable_display_name = dname;
 
                 wavetableIndex = supposedIdx;
             }


### PR DESCRIPTION
As described in #814 double loaded from 203 and extra would double up menus. Fix that

Also update the changelog ready for 2.1.1

Closes #814