### PR TITLE
DAHD Retrigger

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,11 @@
 - Supress some memory leaks in 2.1 due to mis-using `json_set_object` vs
   `json_set_object_new`. This leak motivated the point release even
   though the memory leaked was small.
+- EGxVCA in DAHD Mode changes retrigger semantics slightly. If you have
+  delay set at minimum the delay phase is skipped, so there is no zero
+  segment at the outset; in this case a retrigger of the DAHD will
+  follow the same legato controls as the ADSR. (This basically means
+  "The DAHD works as you would exect in AHD mode with D at min")
 - EGxVCA UI tweaks for control positions, gate time drawing, and labels
 - If you have both 2.0.3 and extra wavetables installed, only scan the
   'extra' downloads copy

--- a/src/EGxVCA.cpp
+++ b/src/EGxVCA.cpp
@@ -201,7 +201,7 @@ struct EnvCurveWidget : rack::Widget, style::StyleParticipant
         auto gtSmp = gt * module->storage->samplerate * BLOCK_SIZE_INV;
 
         auto env = dsp::envelopes::ADSRDAHDEnvelope(module->storage.get());
-        env.attackFrom((dsp::envelopes::ADSRDAHDEnvelope::Mode)shp, 0, as, isDig);
+        env.attackFrom((dsp::envelopes::ADSRDAHDEnvelope::Mode)shp, 0, a, as, isDig);
 
         nvgBeginPath(vg);
         nvgMoveTo(vg, 0, box.size.y - 2); // that's the 0,0 point

--- a/src/EGxVCA.h
+++ b/src/EGxVCA.h
@@ -113,6 +113,15 @@ struct EGxVCA : modules::XTModule
                 return m->tempoSynced;
             return false;
         }
+        bool getMinString(std::string &s) override
+        {
+            if (paramId == EG_A)
+            {
+                s = "Delay Skipped";
+                return true;
+            }
+            return false;
+        }
     };
 
     struct ADSRPQ : modules::CTEnvTimeParamQuantity
@@ -422,7 +431,12 @@ struct EGxVCA : modules::XTModule
                 auto as = (int)std::round(params[A_SHAPE].getValue());
                 auto dig = params[ANALOG_OR_DIGITAL].getValue() < 0.5;
                 auto az = (int)std::round(params[ATTACK_FROM].getValue());
-                processors[c]->attackFrom(m, az * processors[c]->output, as, dig);
+                auto av = modAssist.values[EG_A][c];
+                if (tempoSynced)
+                {
+                    av = aTS + modAssist.modvalues[EG_A][c];
+                }
+                processors[c]->attackFrom(m, az * processors[c]->output, av, as, dig);
                 doAttack[c] = false;
             }
             if (tempoSynced)

--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -1157,6 +1157,14 @@ struct CTEnvTimeParamQuantity : rack::ParamQuantity, modules::CalculatedName
     {
         auto v = getValue() * (etMax - etMin) + etMin;
 
+        if (getValue() < 0.0001)
+        {
+            std::string mv;
+            if (getMinString(mv))
+            {
+                return mv;
+            }
+        }
         if (isTempoSync())
         {
             return temposync_support::temposyncLabel(v);
@@ -1172,6 +1180,7 @@ struct CTEnvTimeParamQuantity : rack::ParamQuantity, modules::CalculatedName
         setValue(vn);
     }
 
+    virtual bool getMinString(std::string &s) { return false; }
     virtual bool isTempoSync() { return false; }
 };
 

--- a/src/dsp/ADSRDAHDEnvelope.h
+++ b/src/dsp/ADSRDAHDEnvelope.h
@@ -71,7 +71,7 @@ struct ADSRDAHDEnvelope
         coeff_offset = 2.f - std::log2(storage->samplerate * BLOCK_SIZE_INV);
     }
 
-    void attackFrom(Mode m, float fv, int ashp, bool isdig)
+    void attackFrom(Mode m, float fv, float attack, int ashp, bool isdig)
     {
         mode = m;
         float f = fv;
@@ -92,7 +92,16 @@ struct ADSRDAHDEnvelope
         }
         phase = f;
         if (m == DAHD_MODE)
-            stage = s_delay;
+        {
+            if (attack > 0.0001)
+            {
+                stage = s_delay;
+            }
+            else
+            {
+                stage = s_attack;
+            }
+        }
         else
             stage = s_attack;
         current = BLOCK_SIZE;


### PR DESCRIPTION
When D in DAHD is at minium, follow the ADSR legato mode and skip the vanishingly small delay step unconditionally (although retrig from zero still will, as will any delay above the min).

Closes #812