### PR TITLE
Fix debug build (typo in assert)

### DIFF
--- a/src/XTModule.h
+++ b/src/XTModule.h
@@ -1092,7 +1092,7 @@ struct TypeSwappingParameterQuantity : rack::ParamQuantity, modules::CalculatedN
     {
         auto m = mode();
         auto f = impls.find(m);
-        assert(f != imps.end());
+        assert(f != impls.end());
         if (f == impls.end())
             return nullptr;
         if (f->second->module != module)


### PR DESCRIPTION
There is a typo inside the assert, leading to a build error if DEBUG is set (which enables assertions)

I suggest to add a debug build to CI to catch these.
