### PR TITLE
Modulated 3D Wavetable Curve didn't Z-Shift

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,10 @@
 # Surge XT VCV Modules Changelog
 
-## 2.1.2 - February 2023
+## 2.1.3
+
+- Fix for wavetable 3d position display when modulating Morph parameter
+
+## 2.1.2 - February 2023 (Skipped in library)
 
 - Add a 'slow' mode to the EGxVCA which allows ADSR times up to 120 seconds
 - Fix an EGxVCA problem where monophonic gates with polyphonic signals would

--- a/src/VCO.cpp
+++ b/src/VCO.cpp
@@ -675,9 +675,17 @@ struct OSCPlotWidget : public rack::widget::TransparentWidget, style::StyleParti
             {
             case ot_wavetable:
             case ot_window:
-                pos = oscdata->p[0].val.f;
-                off = oscdata->p[0].extend_range;
-                break;
+            {
+                auto par = &(oscdata->p[0]);
+                pos = par->val.f;
+                if (module->animateDisplayFromMod)
+                {
+                    pos +=
+                        module->modAssist.modvalues[0 + 1][0] * (par->val_max.f - par->val_min.f);
+                }
+                off = par->extend_range;
+            }
+            break;
             default:
                 pos = 0.f;
                 break;


### PR DESCRIPTION
Fixes this problem by using the modulated value for the z position in the recalc path 3d calculation. Basically a bug when porting from juce.

Closes #841