### PR TITLE
Turn of unmute-on-connect mixer on json unstream

### DIFF
--- a/src/Mixer.h
+++ b/src/Mixer.h
@@ -410,6 +410,11 @@ struct Mixer : modules::XTModule
             vuChannel = 0;
         else
             vuChannel = json_integer_value(v);
+
+        // If we unstream from json let the json win and turn of the
+        // auto-unmute-on-first-connect feature
+        for (auto &ev : everConnected)
+            ev = true;
     }
 };
 } // namespace sst::surgext_rack::mixer


### PR DESCRIPTION
The 'unmute on connect' handy utility conflicted with unstreaming the mute status. So if you unstream json then set the 'ever connected' to true which is best you can do. Closes #852