### PR TITLE
LeftRight Normalization on Mixer; TunedDelays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(SURGE_SKIP_VST3 TRUE CACHE BOOL "skip surge VST3 build")
 set(SURGE_SKIP_ALSA TRUE CACHE BOOL "skip surge Alsa build")
 set(SURGE_SKIP_STANDALONE TRUE CACHE BOOL "skip surge standalone build")
 set(SURGE_COMPILE_BLOCK_SIZE 8 CACHE STRING "surge compile block size")
-set(SURGE_SIMDE_PATH "${RACK_SDK_DIR}/dep/include" CACHE STRING "sirge simde is rack simde")
+set(SURGE_SIMDE_PATH "${RACK_SDK_DIR}/dep/include" CACHE STRING "surge simde is rack simde")
 
 add_subdirectory(surge)
 # turn off specific warning as errors enforced by Rack-SDK compiler options for surge libs

--- a/src/DelayLineByFreq.h
+++ b/src/DelayLineByFreq.h
@@ -107,10 +107,12 @@ struct DelayLineByFreq : modules::XTModule
         outputs[OUTPUT_L].setChannels(cc);
         outputs[OUTPUT_R].setChannels(cc);
 
+        auto rInp = inputs[INPUT_R].isConnected() ? INPUT_R : INPUT_L;
+
         for (int i = 0; i < cc; ++i)
         {
             auto il = inputs[INPUT_L].getVoltage(lm * i);
-            auto ir = inputs[INPUT_R].getVoltage(rm * i);
+            auto ir = inputs[rInp].getVoltage(rm * i);
 
             float pitch0 =
                 (params[VOCT].getValue() + 5) * 12 + inputs[INPUT_VOCT].getVoltage(i) * 12;

--- a/src/DelayLineByFreqExpanded.h
+++ b/src/DelayLineByFreqExpanded.h
@@ -371,6 +371,14 @@ struct DelayLineByFreqExpanded : modules::XTModule
         outputs[OUTPUT_L].setChannels(nChan);
         outputs[OUTPUT_R].setChannels(nChan);
 
+        auto rInput = inputs[INPUT_R].isConnected() ? INPUT_R : INPUT_L;
+        if (rInput == INPUT_L)
+            rm = lm;
+
+        auto rFbInput = inputs[INPUT_FBR].isConnected() ? INPUT_FBR : INPUT_FBL;
+        if (rFbInput == INPUT_FBL)
+            rfm = lfm;
+
         for (int i = 0; i < nChan; ++i)
         {
             float pitch0 =
@@ -404,7 +412,7 @@ struct DelayLineByFreqExpanded : modules::XTModule
             fba = 1.f - omfba * omfba;
 
             auto fbl = fba * inputs[INPUT_FBL].getVoltage(lfm * i);
-            auto fbr = fba * inputs[INPUT_FBR].getVoltage(rfm * i);
+            auto fbr = fba * inputs[rFbInput].getVoltage(rfm * i);
 
             float ex = inputs[INPUT_EXCITER_AMP].getVoltage(i) * 0.1;
             if (ex > 1e-5 && inputs[INPUT_EXCITER_AMP].isConnected())
@@ -436,7 +444,7 @@ struct DelayLineByFreqExpanded : modules::XTModule
             }
 
             auto il = inputs[INPUT_L].getVoltage(lm * i) + fbl;
-            auto ir = inputs[INPUT_R].getVoltage(rm * i) + fbr;
+            auto ir = inputs[rInput].getVoltage(rm * i) + fbr;
 
             // avoid feedback blowouts with a hard clamp
             lineL[i]->write(std::clamp(il, -clampLevel, clampLevel));

--- a/src/Mixer.h
+++ b/src/Mixer.h
@@ -278,7 +278,7 @@ struct Mixer : modules::XTModule
                 polyDepth = std::max(polyDepth, pd);
                 polyDepthPerOsc[(i - INPUT_OSC1_L) / 2] = pd;
             }
-            for (int i=0; i<n_osc; ++i)
+            for (int i = 0; i < n_osc; ++i)
             {
                 if (inputs[INPUT_OSC1_R + i * 2].isConnected())
                 {
@@ -317,9 +317,9 @@ struct Mixer : modules::XTModule
                     osc[i][0][p] =
                         rack::simd::float_4::load(inputs[INPUT_OSC1_L + i * 2].getVoltages(p * 4)) *
                         RACK_TO_SURGE_OSC_MUL;
-                    osc[i][1][p] =
-                        rack::simd::float_4::load(inputs[rightInputFrom[i] + i * 2].getVoltages(p * 4)) *
-                        RACK_TO_SURGE_OSC_MUL;
+                    osc[i][1][p] = rack::simd::float_4::load(
+                                       inputs[rightInputFrom[i] + i * 2].getVoltages(p * 4)) *
+                                   RACK_TO_SURGE_OSC_MUL;
                 }
             }
             else

--- a/src/Mixer.h
+++ b/src/Mixer.h
@@ -248,6 +248,7 @@ struct Mixer : modules::XTModule
 
     int polyDepth{1}, polyDepthBy4{1};
     int polyDepthPerOsc[n_osc];
+    int rightInputFrom[n_osc];
 
     int polyChannelCount() { return polyDepth; }
 
@@ -276,6 +277,17 @@ struct Mixer : modules::XTModule
                 auto pd = inputs[i].getChannels();
                 polyDepth = std::max(polyDepth, pd);
                 polyDepthPerOsc[(i - INPUT_OSC1_L) / 2] = pd;
+            }
+            for (int i=0; i<n_osc; ++i)
+            {
+                if (inputs[INPUT_OSC1_R + i * 2].isConnected())
+                {
+                    rightInputFrom[i] = INPUT_OSC1_R;
+                }
+                else
+                {
+                    rightInputFrom[i] = INPUT_OSC1_L;
+                }
             }
             polyDepthBy4 = (polyDepth - 1) / 4 + 1;
 
@@ -306,7 +318,7 @@ struct Mixer : modules::XTModule
                         rack::simd::float_4::load(inputs[INPUT_OSC1_L + i * 2].getVoltages(p * 4)) *
                         RACK_TO_SURGE_OSC_MUL;
                     osc[i][1][p] =
-                        rack::simd::float_4::load(inputs[INPUT_OSC1_R + i * 2].getVoltages(p * 4)) *
+                        rack::simd::float_4::load(inputs[rightInputFrom[i] + i * 2].getVoltages(p * 4)) *
                         RACK_TO_SURGE_OSC_MUL;
                 }
             }
@@ -318,7 +330,7 @@ struct Mixer : modules::XTModule
                     osc[i][0][p] =
                         RACK_TO_SURGE_OSC_MUL * inputs[INPUT_OSC1_L + i * 2].getVoltage();
                     osc[i][1][p] =
-                        RACK_TO_SURGE_OSC_MUL * inputs[INPUT_OSC1_R + i * 2].getVoltage();
+                        RACK_TO_SURGE_OSC_MUL * inputs[rightInputFrom[i] + i * 2].getVoltage();
                 }
             }
 


### PR DESCRIPTION
The Mixer and TunedDelay didn't follow the protocol that left-only was a stereo signal broadcast to both channels. Correct.

Closes #860