### PR TITLE
Don't paint the LPG response on the Twist scope

### DIFF
--- a/src/vcoconfig/Twist.h
+++ b/src/vcoconfig/Twist.h
@@ -252,7 +252,13 @@ template <> void VCOConfig<ot_twist>::processVCOSpecificParameters(VCO<ot_twist>
 
     for (auto s : {m->oscstorage, m->oscstorage_display})
     {
-        s->p[TwistOscillator::twist_lpg_response].deactivated = !l0;
+        auto deact = !l0;
+        /*
+         * Never paint the LPG on the display
+         */
+        if (s == m->oscstorage_display)
+            deact = true;
+        s->p[TwistOscillator::twist_lpg_response].deactivated = deact;
     }
 }
 


### PR DESCRIPTION
The LPG hides basically all the useful features of the waves when painted for a few cycles so just don't use it on the display oscillator

Closes #846