### PR TITLE
LFO Display Fixes; Under Wav and Bipolar Deform

### DIFF
--- a/src/LFO.h
+++ b/src/LFO.h
@@ -337,6 +337,15 @@ struct LFO : modules::XTModule
 
     int polyChannelCount() { return std::max(1, lastNChan); }
 
+    bool isBipolar(int paramId) override
+    {
+        if (paramId == DEFORM)
+        {
+            return true;
+        }
+        return false;
+    }
+
     int lastStep = BLOCK_SIZE;
     int lastNChan = -1;
     bool firstProcess{true};


### PR DESCRIPTION
1. Always show the LFO wav just lightly, just like in surge
2. Deform is Bipolar! Make the knob bipolar also

CLoses #847