### PR TITLE
Wavetable Painting and Loading Fixes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,23 @@
 # Surge XT VCV Modules Changelog
 
+## 2.1.4 (Coming March 2023)
+
+- EGxVCA: Pan Law is now an option of either the MixMaster
+Stereo Equal Power or True Panning. Stereo Equal Power is
+the new default, matching MixMaster. *This will change the
+behavior of EGxVCA pan in saved patches unless you explicitly
+restore the True Panning mode in the menu*.
+- Mixer, TunedDelays: Left/Mono normalize properly.
+- Mixer: Turn of the 'unmute-on-connect' mixer behavior when unstreaming, allowing
+mute to save correctly
+- Twist: Don't paint the Twist waveform with the LPG on
+- LFOxEG: Imporove wording on "Set EG to Zero" on LFO
+- LFOxEG: Paint the raw wave as a 'ghost' wave in the LFO display
+- LFOxEG: Adjust the Phase/Shuffle label on the LFO front pane
+- WaveTable/Window: Fix several problems with loading incomplete wavetables and
+painting the resulting wavetable display.
+- Infrastructure: Make Surge's use of SIMDE compile time selectable; use rack SIMDE
+
 ## 2.1.3
 
 - Fix for wavetable 3d position display when modulating Morph parameter

--- a/src/VCO.cpp
+++ b/src/VCO.cpp
@@ -480,6 +480,9 @@ struct OSCPlotWidget : public rack::widget::TransparentWidget, style::StyleParti
         {
             recalcPath();
             bdwPlot->dirty = true;
+            // Oh dirty can also change the background not just the plot
+            // if features like oneshot changes
+            bdw->dirty = true;
         }
 
         if constexpr (VCOConfig<oscType>::requiresWavetables())
@@ -648,8 +651,11 @@ struct OSCPlotWidget : public rack::widget::TransparentWidget, style::StyleParti
 
         if (VCOConfig<oscType>::requiresWavetables())
         {
-            if (module->wavetableCount == 0)
+            if (module && module->wavetableCount == 0)
                 return;
+
+            if (module)
+                isOneShot = module->isWTOneShot();
         }
 
         if (module && module->draw3DWavetable)


### PR DESCRIPTION
1. Fill frames for truncated tables with 0, fixing a problem with pulse wavetable in rack. Closes #843

2. Invalidate more completely when dirty since background is dirty dependent. Addresses #856 but will await for confirm to close