### PR TITLE
Un-shadow Module and ParamID in ParamStepped

### DIFF
--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -1829,8 +1829,6 @@ typedef GenericPresetJogSelector<rack::ParamWidget> ParamJogSelector;
 
 struct SteppedParamAsPresetJog : GenericPresetJogSelector<rack::ParamWidget>
 {
-    modules::XTModule *module{nullptr};
-    int paramId;
     int lastValue{-1};
     void setup() override
     {


### PR DESCRIPTION
ParamStepped used to be not a param widget but now it is; but we still had the apocryphal shadows of module and paramid. This was fine-ish except when you asked for widget->getParamQuantity in a context where you didn't check for NULL. Stormelder strip is such a context so this would crash when strip randomized.

Closes #876