### PR TITLE
InputInput

### DIFF
--- a/src/Delay.h
+++ b/src/Delay.h
@@ -172,7 +172,7 @@ struct Delay : modules::XTModule
 
         configInput(INPUT_L, "Left");
         configInput(INPUT_R, "Right");
-        configInput(INPUT_CLOCK, "Clock/BPM Input");
+        configInput(INPUT_CLOCK, "Clock/BPM");
         for (int i = 0; i < n_mod_inputs; ++i)
             configInput(DELAY_MOD_INPUT + i, std::string("Mod ") + std::to_string(i + 1));
         configOutput(OUTPUT_L, "Left");

--- a/src/DelayLineByFreqExpanded.h
+++ b/src/DelayLineByFreqExpanded.h
@@ -191,17 +191,17 @@ struct DelayLineByFreqExpanded : modules::XTModule
             configParamNoRand(MOD_PARAM_0 + i, -1, 1, 0, name, "%", 0, 100);
         }
 
-        configInput(INPUT_L, "In Left");
-        configInput(INPUT_R, "In Right");
+        configInput(INPUT_L, "Left");
+        configInput(INPUT_R, "Right");
         configInput(INPUT_VOCT, "Delay Time as Frequency in v/oct");
 
-        configInput(INPUT_FBL, "Feedback Input Left");
-        configInput(INPUT_FBR, "Feedback Input RIGHT");
+        configInput(INPUT_FBL, "Feedback Left");
+        configInput(INPUT_FBR, "Feedback Right");
         configInput(INPUT_EXCITER_AMP, "Noise Source Amplitude");
 
         for (int i = 0; i < n_mod_inputs; ++i)
         {
-            configInput(MOD_INPUT_0 + i, "Mod " + std::to_string(i + 1) + " Input");
+            configInput(MOD_INPUT_0 + i, "Mod " + std::to_string(i + 1));
         }
 
         configOutput(OUTPUT_L, "Out Left");

--- a/src/VCO.h
+++ b/src/VCO.h
@@ -252,7 +252,7 @@ template <int oscType> struct VCO : public modules::XTModule
 
         configInput(PITCH_CV, "V/Oct");
         configInput(RETRIGGER, "Reset/Retrigger");
-        configInput(AUDIO_INPUT, "Audio Input");
+        configInput(AUDIO_INPUT, "Audio");
         for (int m = 0; m < n_mod_inputs; ++m)
         {
             auto s = std::string("Modulation Signal ") + std::to_string(m + 1);


### PR DESCRIPTION
Rack adds "input" to input tooltips so an input named "Audio Input" shows a tooltip of "Audio Input Input". Fix.

Closes #878