### PR TITLE
Make the WaveShaper display system-wide

### DIFF
--- a/src/Waveshaper.h
+++ b/src/Waveshaper.h
@@ -195,7 +195,6 @@ struct Waveshaper : public modules::XTModule
     int monoChannelOffset{0};
 
     std::atomic<bool> doDCBlock{true};
-    std::atomic<bool> showTransformCurve{true};
     bool wasDoDCBlock{true};
     /*
      * This is a bit annoying - i don't want to break 2.0.3.0 patches by turning on
@@ -571,7 +570,6 @@ struct Waveshaper : public modules::XTModule
     {
         auto ws = json_object();
         json_object_set_new(ws, "doDCBlock", json_boolean(doDCBlock));
-        json_object_set_new(ws, "showTransformCurve", json_boolean(showTransformCurve));
         return ws;
     }
 
@@ -586,12 +584,6 @@ struct Waveshaper : public modules::XTModule
         else
         {
             doDCBlock = true;
-        }
-
-        auto stc = json_object_get(modJ, "showTransformCurve");
-        if (stc)
-        {
-            showTransformCurve = json_boolean_value(stc);
         }
     }
 };

--- a/src/XTStyle.cpp
+++ b/src/XTStyle.cpp
@@ -146,6 +146,7 @@ void XTStyle::initialize()
         handleBool("showModulationAnimationOnKnobs", setShowModulationAnimationOnKnobs, true);
         handleBool("showModulationAnimationOnDisplay", setShowModulationAnimationOnDisplay, true);
         handleBool("showShadows", setShowShadows, true);
+        handleBool("waveshaperShowsBothCurves", setWaveshaperShowsBothCurves, false);
 
         json_decref(fd);
     }
@@ -161,6 +162,7 @@ static bool showKnobValuesAtRest{true};
 static bool showModulationAnimationOnKnobs{true};
 static bool showModulationAnimationOnDisplay{true};
 static bool showShadows{true};
+static bool waveshaperShowsBothCurves{false};
 
 static std::shared_ptr<XTStyle> constructDefaultStyle()
 {
@@ -255,6 +257,17 @@ void XTStyle::setShowShadows(bool b)
     }
 }
 
+bool XTStyle::getWaveshaperShowsBothCurves() { return waveshaperShowsBothCurves; }
+void XTStyle::setWaveshaperShowsBothCurves(bool b)
+{
+    if (b != waveshaperShowsBothCurves)
+    {
+        waveshaperShowsBothCurves = b;
+        updateJSON();
+        notifyStyleListeners();
+    }
+}
+
 void XTStyle::setGlobalModulationColor(sst::surgext_rack::style::XTStyle::LightColor c)
 {
     if (c != defaultGlobalModulationColor)
@@ -319,6 +332,8 @@ void XTStyle::updateJSON()
     json_object_set_new(rootJ, "showModulationAnimationOnDisplay",
                         json_boolean(showModulationAnimationOnDisplay));
     json_object_set_new(rootJ, "showShadows", json_boolean(showShadows));
+    json_object_set_new(rootJ, "waveshaperShowsBothCurves",
+                        json_boolean(waveshaperShowsBothCurves));
     FILE *f = std::fopen(defaultsFile.c_str(), "w");
     if (f)
     {

--- a/src/XTStyle.h
+++ b/src/XTStyle.h
@@ -83,6 +83,9 @@ struct XTStyle
     static bool getShowShadows();
     static void setShowShadows(bool b);
 
+    static bool getWaveshaperShowsBothCurves();
+    static void setWaveshaperShowsBothCurves(bool b);
+
     static std::string lightColorName(LightColor c);
     static NVGcolor lightColorColor(LightColor c);
 


### PR DESCRIPTION
Make the waveshaper display system wide style level setting. Default it to the old display (single curve).

Closes #883