### PR TITLE
Unison CV Expander

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -435,6 +435,15 @@
         "Utility",
         "Polyphonic"
       ]
+    },
+    {
+      "slug": "SurgeXTUnisonHelperCVExpander",
+      "name": "UnisonHelper CV Expander",
+      "description": "Expander for the Unison Helper which allows you to co-route CV",
+      "tags": [
+        "Utility",
+        "Polyphonic"
+      ]
     }
   ]
 }

--- a/src/SurgeXT.cpp
+++ b/src/SurgeXT.cpp
@@ -77,6 +77,7 @@ __attribute__((__visibility__("default"))) void init(rack::Plugin *p)
     p->addModel(modelQuadLFO);
 
     p->addModel(modelUnisonHelper);
+    p->addModel(modelUnisonHelperCVExpander);
 
     sst::surgext_rack::style::XTStyle::initialize();
 }

--- a/src/SurgeXT.h
+++ b/src/SurgeXT.h
@@ -96,5 +96,6 @@ extern rack::Model *modelQuadAD;
 extern rack::Model *modelQuadLFO;
 
 extern rack::Model *modelUnisonHelper;
+extern rack::Model *modelUnisonHelperCVExpander;
 
 #endif // SCXT_SRC_SURGEXT_H

--- a/src/XTWidgets.h
+++ b/src/XTWidgets.h
@@ -1612,6 +1612,7 @@ struct PlotAreaLabel : public rack::Widget, style::StyleParticipant
     BufferedDrawFunctionWidget *bdw{nullptr};
     std::string label;
     bool upcaseDisplay{true};
+    bool centerDisplay{false};
 
     static PlotAreaLabel *create(rack::Vec pos, rack::Vec sz)
     {
@@ -1640,8 +1641,16 @@ struct PlotAreaLabel : public rack::Widget, style::StyleParticipant
         nvgFillColor(vg, style()->getColor(style::XTStyle::PLOT_CONTROL_TEXT));
         nvgFontFaceId(vg, style()->fontIdBold(vg));
         nvgFontSize(vg, layout::LayoutConstants::labelSize_pt * 96 / 72);
-        nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-        nvgText(vg, rack::mm2px(0.5), box.size.y * 0.5, pv.c_str(), nullptr);
+        if (centerDisplay)
+        {
+            nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+            nvgText(vg, box.size.x * 0.5, box.size.y * 0.5, pv.c_str(), nullptr);
+        }
+        else
+        {
+            nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+            nvgText(vg, rack::mm2px(0.5), box.size.y * 0.5, pv.c_str(), nullptr);
+        }
     }
 
     void onStyleChanged() override { bdw->dirty = true; }


### PR DESCRIPTION
The unison CV expander allows you to route poly or mono CV alongside the unison layout to modulate your target VCO

Closes #928