### PR TITLE
Add v/oct modulation for frequency surge params

### DIFF
--- a/docs/nightlychangelog.md
+++ b/docs/nightlychangelog.md
@@ -34,5 +34,6 @@
 - Remove some uneeded pre-XT content from the vcvplugin build step
 - Align the EGxVCA envelope/meter split with the knobs. Once you see it
   you just gotta fix it!
+- Modulating a frequncy-style surge parameter gets a 'set to 1oct/v' menu item
+  in the RMB.
 - Cache the WT conversion for saving into your patch in the WT/Window VCO
-- 


### PR DESCRIPTION
If a param is a ct_freq_blah with rang > 120, add a v/oct auto modulation menu item to the RMB.

Closes #610