### PR TITLE
EGxVCA Poly Trigger on Channel Change

### DIFF
--- a/docs/nightlychangelog.md
+++ b/docs/nightlychangelog.md
@@ -41,3 +41,7 @@
 - Cache the WT conversion for saving into your patch in the WT/Window VCO
 - In rare cases the SpringReverb could NaN. Reset the effect automatically if
   these occur as a workaround.
+- The EGxVCA didn't trigger envelopes for newly added polyphony while
+  the gate was high. This caused polyphony mis-fires on patch startup
+  in some rare cases. Now it will trigger an envlope for a
+  newly added channel in a high gate situation.

--- a/src/EGxVCA.h
+++ b/src/EGxVCA.h
@@ -415,7 +415,7 @@ struct EGxVCA : modules::XTModule, sst::rackhelpers::module_connector::NeighborC
     int processCount{BLOCK_SIZE};
     int meterUpdateCount{0};
 
-    int nChan{-1};
+    int nChan{-1}, priorNChan{-1};
     bool polyGate{false};
 
     bool doAttack[MAX_POLY];
@@ -453,6 +453,19 @@ struct EGxVCA : modules::XTModule, sst::rackhelpers::module_connector::NeighborC
             nChan = std::max({inputs[INPUT_L].getChannels(), inputs[INPUT_R].getChannels(),
                               inputs[GATE_IN].getChannels(), 1});
             polyGate = inputs[GATE_IN].getChannels() > 1;
+
+            if (nChan != priorNChan)
+            {
+                if (priorNChan > 0 && nChan > priorNChan)
+                {
+                    for (int c = priorNChan; c < nChan; ++c)
+                    {
+                        // we want to newly check the schmidt trigger
+                        triggers[c].state = false;
+                    }
+                }
+                priorNChan = nChan;
+            }
 
             modAssist.setupMatrix(this);
             modAssist.updateValues(this);


### PR DESCRIPTION
EGxVCA didn't reset schmidt triggers when channels changed. This meant in some startup cases, with a poly signal and a mono gate, the first gate fired at startup would not trigger the envelopes (but the second and subsequent worked fine).

Fix this in the general case of poly-changes-while-gate-high

Closes #874