### PR TITLE
LFOxEG GATE/GATEENV fixes

### DIFF
--- a/docs/nightlychangelog.md
+++ b/docs/nightlychangelog.md
@@ -45,3 +45,6 @@
   the gate was high. This caused polyphony mis-fires on patch startup
   in some rare cases. Now it will trigger an envlope for a
   newly added channel in a high gate situation.
+- Rework the LFOxEG gate behavior so the code is less confusing.
+  As a result, fix a bug where the envelope would mis-trigger when
+  both GATE and GATEENV were connected.


### PR DESCRIPTION
Rework the innards of LFOxEG to be way less confusing with better named variables etc

As a result, fix a bug which occured when both GATE and GATEENV were connected.

Closes #850

Also bring Surge up to the 1.3 candidate