### PR TITLE
Remove the copy of sst-basic-blocks now surge has it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "surge"]
 	path = surge
 	url = https://github.com/surge-synthesizer/surge.git
-[submodule "libs/sst/sst-basic-blocks"]
-	path = libs/sst/sst-basic-blocks
-	url = https://github.com/surge-synthesizer/sst-basic-blocks.git
 [submodule "libs/sst-rackhelpers"]
 	path = libs/sst-rackhelpers
 	url = https://github.com/surge-synthesizer/sst-rackhelpers


### PR DESCRIPTION
With surge 1.3 there's a basic-blocks in there already