### PR TITLE
Nimbus Randomizacion Control

### DIFF
--- a/src/FX.cpp
+++ b/src/FX.cpp
@@ -64,6 +64,8 @@ template <int fxType> struct FXWidget : public widgets::XTModuleWidget
         {
             addClockMenu<FX<fxType>>(menu);
         }
+
+        FXConfig<fxType>::addFXSpecificMenuItems(xtm, menu);
     }
 };
 

--- a/src/FX.h
+++ b/src/FX.h
@@ -77,6 +77,8 @@ template <int fxType> struct FXConfig
     static constexpr float rescaleInputFactor() { return 1.0; }
     static constexpr bool softclipOutput() { return false; }
     static constexpr bool nanCheckOutput() { return false; }
+
+    static void addFXSpecificMenuItems(FX<fxType> *M, rack::ui::Menu *) {}
 };
 
 template <int fxType>


### PR DESCRIPTION
Closes #958

Basically the mode and quality can be excluded from randomization and are by default. Just like twist.