### PR TITLE
Up the Digital RingMod oversample latency to 8

### DIFF
--- a/docs/nightlychangelog.md
+++ b/docs/nightlychangelog.md
@@ -1,4 +1,4 @@
-## 2.2.0 
+## 2.2.1
 
 ### New Modules
   - Bonsai
@@ -48,3 +48,4 @@
 - Rework the LFOxEG gate behavior so the code is less confusing.
   As a result, fix a bug where the envelope would mis-trigger when
   both GATE and GATEENV were connected.
+- VCO Character, Level and Drift don't participate in randomization

--- a/src/DigitalRingMod.h
+++ b/src/DigitalRingMod.h
@@ -312,12 +312,12 @@ struct DigitalRingMod : modules::XTModule,
 
     std::array<std::array<std::unique_ptr<sst::filters::HalfRate::HalfRateFilter>, MAX_POLY>, 2>
         halfbandInA, halfbandInB, halfbandOut;
-    static constexpr int blockSize{4}, blockSizeOS{blockSize << 1};
-    float inputA[2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
+    static constexpr int blockSize{8}, blockSizeOS{blockSize << 1};
+    float inputA alignas(16) [2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
     bool aMono[2]{false, false};
-    float inputB[2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
+    float inputB alignas(16) [2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
     bool bMono[2]{false, false};
-    float output[2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
+    float output alignas(16) [2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
     int blockPos{0};
     int poly[2]{1, 1};
 };

--- a/src/DigitalRingMod.h
+++ b/src/DigitalRingMod.h
@@ -313,11 +313,11 @@ struct DigitalRingMod : modules::XTModule,
     std::array<std::array<std::unique_ptr<sst::filters::HalfRate::HalfRateFilter>, MAX_POLY>, 2>
         halfbandInA, halfbandInB, halfbandOut;
     static constexpr int blockSize{8}, blockSizeOS{blockSize << 1};
-    float inputA alignas(16) [2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
+    float inputA alignas(16)[2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
     bool aMono[2]{false, false};
-    float inputB alignas(16) [2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
+    float inputB alignas(16)[2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
     bool bMono[2]{false, false};
-    float output alignas(16) [2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
+    float output alignas(16)[2][MAX_POLY][2][blockSize]; // 0,1; poly; L/R
     int blockPos{0};
     int poly[2]{1, 1};
 };

--- a/src/VCO.h
+++ b/src/VCO.h
@@ -248,9 +248,9 @@ struct VCO : public modules::XTModule, sst::rackhelpers::module_connector::Neigh
         configParamNoRand(RETRIGGER_STYLE, 0, 1, 0, "Random Phase on Retrigger");
         configParamNoRand(EXTEND_UNISON, 0, 1, 0, "Extend Unison");
         configParamNoRand(ABSOLUTE_UNISON, 0, 1, 0, "Absolute Unison");
-        configParam(CHARACTER, 0, 2, 1, "Character Filter");
-        configParam(DRIFT, 0, 1, 0, "Oscillator Drift", "%", 0, 100);
-        configParam(FIXED_ATTENUATION, 0, 1, 1, "Output Level", "%", 0, 100);
+        configParamNoRand(CHARACTER, 0, 2, 1, "Character Filter");
+        configParamNoRand(DRIFT, 0, 1, 0, "Oscillator Drift", "%", 0, 100);
+        configParamNoRand(FIXED_ATTENUATION, 0, 1, 1, "Output Level", "%", 0, 100);
 
         VCOConfig<oscType>::configureVCOSpecificParameters(this);
         config_osc->~Oscillator();


### PR DESCRIPTION
The halfrate filter doesn't work at block size 4 currently.