### PR TITLE
Quad LFO Independent Trigger Fix

### DIFF
--- a/src/QuadLFO.h
+++ b/src/QuadLFO.h
@@ -904,7 +904,8 @@ struct QuadLFO : modules::XTModule
             for (int c = 0; c < chanByLFO[i]; ++c)
             {
                 auto r = RateQuantity::independentRateScale(modAssist.values[RATE_0 + i][c]);
-                if (ic && triggers[i][c].process(inputs[TRIGGER_0].getVoltage(c * (!monoTrigger))))
+                if (ic &&
+                    triggers[i][c].process(inputs[TRIGGER_0 + i].getVoltage(c * (!monoTrigger))))
                 {
                     processors[i][c]->attack(shape);
                 }


### PR DESCRIPTION
Quad LFO mis-read the trigger index meaning defacto only the first LFOs trigger would trigger the LFO in independent mode.

Fix this with a 3 char fix to use the right input for the trigger

Closes #970