### PR TITLE
Less cardinal specific changes

### DIFF
--- a/src/XTStyle.cpp
+++ b/src/XTStyle.cpp
@@ -42,7 +42,7 @@ void XTStyle::initialize()
     if (!fd)
     {
 #ifdef USING_CARDINAL_NOT_RACK
-        setGlobalStyle(rack::settings::darkMode ? DARK : LIGHT);
+        setGlobalStyle(rack::settings::preferDarkPanels ? DARK : LIGHT);
 #else
         setGlobalStyle(MID);
 #endif


### PR DESCRIPTION
Now that VCV Rack has an official dark theme switch we can get a bit closer to the official Rack approach.
The Cardinal custom `rack::settings::darkMode` is being deprecated in favour of the official `rack::settings::preferDarkPanels`

I still do not like having the "mid" as the initial surge theme though, so light/dark switch remains for the initial/first instance of your plugins.

Thanks for the nice modules once again

Next Cardinal release is planned for 15th of January btw.