### PR TITLE
Fix uninitalized values in Waveshaper

### DIFF
--- a/src/Waveshaper.h
+++ b/src/Waveshaper.h
@@ -147,6 +147,9 @@ struct Waveshaper : public modules::XTModule,
 
         modulationAssistant.initialize(this);
 
+        // initialize values, they can be used by the UI before processing if plugin is bypassed
+        modulationAssistant.updateValues(this);
+
         configBypass(INPUT_L, OUTPUT_L);
         configBypass(INPUT_R, OUTPUT_R);
     }
@@ -200,7 +203,7 @@ struct Waveshaper : public modules::XTModule,
     int lastPolyL{-2}, lastPolyR{-2};
     int monoChannelOffset{0};
 
-    std::atomic<int> displayPolyChannel;
+    std::atomic<int> displayPolyChannel{0};
     std::atomic<bool> doDCBlock{true};
     bool wasDoDCBlock{true};
     /*


### PR DESCRIPTION
Fixes #992

1st change is needed for the case where plugin UI runs while Rack/Cardinal is bypassed which makes this:
```
ddb = module->modulationAssistant.values[Waveshaper::DRIVE][ch];
```
read uninitialized values (they are only set during processing)

2nd change is more obvious, fixes the use of `displayPolyChannel` which does not have a value set.
This also matches what https://cplusplus.com/reference/atomic/atomic/atomic/ says

> (1) default constructor
>    Leaves the [atomic](https://cplusplus.com/atomic) object in an uninitialized state.

which I didn't know it was a thing, I thought `std::atomic` types would initialize to 0...
