### PR TITLE
Do not use -fno-char8_t on regular builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ target_sources(${RACK_PLUGIN_LIB} PRIVATE
         src/XTWidgets.cpp)
 
 target_link_libraries(${RACK_PLUGIN_LIB} PRIVATE Surge sst-rackhelpers)
-target_compile_options(${RACK_PLUGIN_LIB} PUBLIC -fno-char8_t -Wno-sign-compare)
+target_compile_options(${RACK_PLUGIN_LIB} PUBLIC -Wno-sign-compare)
 
 file(COPY surge/resources/surge-shared/configuration.xml
              surge/resources/surge-shared/windows.wt


### PR DESCRIPTION
There is still a `-fno-char8_t` in place which breaks builds with GCC7, which can be removed since a few lines above we have:

```
if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
  message(STATUS "Turning on fno-char8_t for c++20")
  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-char8_t>)
endif()
```
