### PR TITLE
Upgrade Surge; FPU Guard VCF

### DIFF
--- a/src/VCF.h
+++ b/src/VCF.h
@@ -343,7 +343,7 @@ struct VCF : public modules::XTModule, sst::rackhelpers::module_connector::Neigh
 
     void process(const typename rack::Module::ProcessArgs &args) override
     {
-        // auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
+        auto fpuguard = sst::plugininfra::cpufeatures::FPUStateGuard();
 
         auto ftype = (sst::filters::FilterType)(int)(std::round(params[VCF_TYPE].getValue()));
         auto fsubtype =


### PR DESCRIPTION
Upgrade surge to 1.3.2

Also set the FPU guard in the VCF to perhaps address #1001

If this doesn't fix #1001 back down that FPU Guard