### PR TITLE
Deal with deactivated params

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -63,7 +63,7 @@ jobs:
   build-mac:
     name: mac
     needs: modify-plugin-version
-    runs-on: macos-12
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:

--- a/src/FX.h
+++ b/src/FX.h
@@ -237,6 +237,10 @@ struct FX : modules::XTModule, sst::rackhelpers::module_connector::NeighborConne
         setupSurgeCommon(NUM_PARAMS, false, true);
 
         fxstorage = &(storage->getPatch().fx[0]);
+        // Surge proper defaults this to true then uses the patch loader to set it to false
+        // based on version. We don't do the patch load here so...
+        for (int i=0; i<n_fx_params; ++i)
+            fxstorage->p[i].deactivated = false;
         fxstorage->type.val.i = fxType;
 
         setupStorageRanges(&(fxstorage->type), &(fxstorage->p[n_fx_params - 1]));

--- a/src/FX.h
+++ b/src/FX.h
@@ -239,7 +239,7 @@ struct FX : modules::XTModule, sst::rackhelpers::module_connector::NeighborConne
         fxstorage = &(storage->getPatch().fx[0]);
         // Surge proper defaults this to true then uses the patch loader to set it to false
         // based on version. We don't do the patch load here so...
-        for (int i=0; i<n_fx_params; ++i)
+        for (int i = 0; i < n_fx_params; ++i)
             fxstorage->p[i].deactivated = false;
         fxstorage->type.val.i = fxType;
 


### PR DESCRIPTION
params default to deact true and surge patch load, which we run in vst startup, sets them to false, but the phaser was exposed to that not happening, so hard set the fx deact to false and then load and init.