### PR TITLE
Tactical fix for cmake 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/.#*
 .idea
 dep/
 cmake-build*
+ignore/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+set(CMAKE_POLICY_VERSION_MINIMUM "3.5" CACHE STRING "Fix up libsamplerate in rack side")
 project(SurgeXTRack VERSION 1.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Tactical fix for cmake 4; basically force the surge rack cmake to set the minimum policy thingy