### PR TITLE
Workaroudn LFO hang when process is not called

### DIFF
--- a/src/LFO.cpp
+++ b/src/LFO.cpp
@@ -695,6 +695,9 @@ struct LFOWaveform : rack::Widget, style::StyleParticipant
 
     void drawWaveform(NVGcontext *vg)
     {
+        if (!module->processHasRun)
+            return;
+
         auto lfodata = module->lfostorageDisplay;
         auto storage = module->storage.get();
 

--- a/src/LFO.h
+++ b/src/LFO.h
@@ -132,6 +132,7 @@ struct LFO : modules::XTModule
     LFOStorage *lfostorageDisplay;
     std::atomic<bool> retriggerFromZero{false};
     std::atomic<float> onepoleFactor{0.75f};
+    std::atomic<bool> processHasRun{false};
 
     modules::ModulationAssistant<LFO, n_lfo_params, RATE, n_mod_inputs, LFO_MOD_INPUT> modAssist;
 
@@ -713,6 +714,8 @@ struct LFO : modules::XTModule
                 }
             }
         }
+
+        processHasRun = true;
     }
 
     int pulseSamples{48000 / 100};


### PR DESCRIPTION
Something in the process param setup is required for the LFO to draw properly. Ugh. Rack threading is really annoying. But anyway rather than fix it, just don't draw the LFO absent a process thread for now.